### PR TITLE
feat: manual review import (CSV) into reviews table

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ docker compose up --build
 - Apply migrations: `npm run db:migrate`
 - Health check query: `npm run db:health`
 - Query helper: `lib/db.ts` (`query(...)` over `pg` pool)
+
+## Manual CSV import (MVP)
+
+- UI page: `/import`
+- Create/select a business, upload CSV, and import reviews into `reviews` with `source="manual"`.
+- Supported CSV columns:
+  - required: `rating`, `text`, `reviewed_at` (ISO)
+  - optional: `author_name`

--- a/app/api/businesses/route.ts
+++ b/app/api/businesses/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { query } from "../../../lib/db";
+
+export async function GET() {
+  const result = await query<{ id: number; name: string }>(
+    "SELECT id, name FROM businesses ORDER BY id ASC"
+  );
+  return NextResponse.json({ businesses: result.rows });
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const name = String(body?.name ?? "").trim();
+  const timezone = String(body?.timezone ?? "America/Toronto").trim();
+
+  if (!name) {
+    return NextResponse.json({ error: "name is required" }, { status: 400 });
+  }
+
+  const result = await query<{ id: number; name: string }>(
+    `INSERT INTO businesses (name, timezone, brand_colors)
+     VALUES ($1, $2, '{}'::jsonb)
+     RETURNING id, name`,
+    [name, timezone]
+  );
+
+  return NextResponse.json({ business: result.rows[0] }, { status: 201 });
+}

--- a/app/api/reviews/import/route.ts
+++ b/app/api/reviews/import/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { query } from "../../../../lib/db";
+import { parseCsv } from "../../../../lib/csv";
+
+export async function POST(req: NextRequest) {
+  const formData = await req.formData();
+  const businessIdRaw = String(formData.get("businessId") ?? "").trim();
+  const file = formData.get("file");
+
+  const businessId = Number(businessIdRaw);
+  if (!Number.isInteger(businessId) || businessId <= 0) {
+    return NextResponse.json({ error: "valid businessId is required" }, { status: 400 });
+  }
+
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "file is required" }, { status: 400 });
+  }
+
+  const csvText = await file.text();
+  let rows;
+  try {
+    rows = parseCsv(csvText);
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "invalid CSV" },
+      { status: 400 }
+    );
+  }
+
+  let imported = 0;
+  let skippedEmpty = 0;
+  let rejectedInvalid = 0;
+
+  for (const row of rows) {
+    const ratingText = row.rating.trim();
+    const text = row.text.trim();
+    const reviewedAt = row.reviewed_at.trim();
+    const authorName = row.author_name?.trim() || null;
+
+    if (!ratingText && !text && !reviewedAt && !authorName) {
+      skippedEmpty += 1;
+      continue;
+    }
+
+    if (!ratingText || !text) {
+      rejectedInvalid += 1;
+      continue;
+    }
+
+    const rating = Number(ratingText);
+    const date = new Date(reviewedAt);
+    if (!Number.isFinite(rating) || rating < 1 || rating > 5 || Number.isNaN(date.getTime())) {
+      rejectedInvalid += 1;
+      continue;
+    }
+
+    await query(
+      `INSERT INTO reviews
+      (business_id, source, source_review_id, rating, author_name, text, reviewed_at)
+      VALUES ($1, 'manual', NULL, $2, $3, $4, $5)`,
+      [businessId, Math.round(rating), authorName, text, date.toISOString()]
+    );
+    imported += 1;
+  }
+
+  return NextResponse.json({ imported, skippedEmpty, rejectedInvalid });
+}

--- a/app/api/reviews/route.ts
+++ b/app/api/reviews/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { query } from "../../../lib/db";
+
+export async function GET(req: NextRequest) {
+  const businessId = req.nextUrl.searchParams.get("businessId");
+  if (!businessId) {
+    return NextResponse.json({ error: "businessId is required" }, { status: 400 });
+  }
+
+  const result = await query<{
+    id: number;
+    rating: number;
+    author_name: string | null;
+    text: string;
+    reviewed_at: string;
+  }>(
+    `SELECT id, rating, author_name, text, reviewed_at::text
+     FROM reviews
+     WHERE business_id = $1
+     ORDER BY reviewed_at DESC, id DESC
+     LIMIT 100`,
+    [Number(businessId)]
+  );
+
+  return NextResponse.json({ reviews: result.rows });
+}

--- a/app/import/page.tsx
+++ b/app/import/page.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+
+type Business = { id: number; name: string };
+type Review = {
+  id: number;
+  rating: number;
+  author_name: string | null;
+  text: string;
+  reviewed_at: string;
+};
+
+export default function ImportPage() {
+  const [businesses, setBusinesses] = useState<Business[]>([]);
+  const [selectedBusinessId, setSelectedBusinessId] = useState<string>("");
+  const [newBusinessName, setNewBusinessName] = useState("");
+  const [result, setResult] = useState<string>("");
+  const [reviews, setReviews] = useState<Review[]>([]);
+
+  async function loadBusinesses() {
+    const res = await fetch("/api/businesses");
+    const data = await res.json();
+    setBusinesses(data.businesses ?? []);
+  }
+
+  async function loadReviews(businessId: string) {
+    if (!businessId) {
+      setReviews([]);
+      return;
+    }
+    const res = await fetch(`/api/reviews?businessId=${businessId}`);
+    const data = await res.json();
+    setReviews(data.reviews ?? []);
+  }
+
+  useEffect(() => {
+    loadBusinesses();
+  }, []);
+
+  useEffect(() => {
+    loadReviews(selectedBusinessId);
+  }, [selectedBusinessId]);
+
+  async function createBusiness(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const name = newBusinessName.trim();
+    if (!name) return;
+
+    const res = await fetch("/api/businesses", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name, timezone: "America/Toronto" })
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      setResult(`Create business failed: ${data.error ?? "unknown error"}`);
+      return;
+    }
+
+    setNewBusinessName("");
+    await loadBusinesses();
+    setSelectedBusinessId(String(data.business.id));
+    setResult(`Created business: ${data.business.name}`);
+  }
+
+  async function importCsv(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+    formData.set("businessId", selectedBusinessId);
+
+    const res = await fetch("/api/reviews/import", { method: "POST", body: formData });
+    const data = await res.json();
+    if (!res.ok) {
+      setResult(`Import failed: ${data.error ?? "unknown error"}`);
+      return;
+    }
+
+    setResult(
+      `Imported ${data.imported}, skipped empty ${data.skippedEmpty}, rejected ${data.rejectedInvalid}`
+    );
+
+    await loadReviews(selectedBusinessId);
+    form.reset();
+  }
+
+  return (
+    <main style={{ fontFamily: "sans-serif", padding: 24, maxWidth: 920 }}>
+      <h1>Manual review import (CSV)</h1>
+
+      <section style={{ marginBottom: 20 }}>
+        <h2>Create business</h2>
+        <form onSubmit={createBusiness}>
+          <input
+            value={newBusinessName}
+            onChange={(e) => setNewBusinessName(e.target.value)}
+            placeholder="Business name"
+          />
+          <button type="submit" style={{ marginLeft: 8 }}>
+            Create
+          </button>
+        </form>
+      </section>
+
+      <section style={{ marginBottom: 20 }}>
+        <h2>Select business</h2>
+        <select
+          value={selectedBusinessId}
+          onChange={(e) => setSelectedBusinessId(e.target.value)}
+        >
+          <option value="">Select…</option>
+          {businesses.map((b) => (
+            <option key={b.id} value={b.id}>
+              {b.name}
+            </option>
+          ))}
+        </select>
+      </section>
+
+      <section style={{ marginBottom: 20 }}>
+        <h2>Upload CSV</h2>
+        <p>Required columns: rating, text, reviewed_at (ISO). Optional: author_name.</p>
+        <form onSubmit={importCsv}>
+          <input type="file" name="file" accept=".csv,text/csv" required />
+          <button type="submit" disabled={!selectedBusinessId} style={{ marginLeft: 8 }}>
+            Import
+          </button>
+        </form>
+      </section>
+
+      {result ? <p><strong>{result}</strong></p> : null}
+
+      <section>
+        <h2>Imported reviews (latest 100)</h2>
+        <ul>
+          {reviews.map((r) => (
+            <li key={r.id}>
+              <strong>{r.rating}★</strong> {r.author_name ? `(${r.author_name})` : ""} — {r.text}
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,13 @@
+import Link from "next/link";
+
 export default function HomePage() {
   return (
     <main style={{ padding: 24, fontFamily: "sans-serif" }}>
       <h1>hello</h1>
       <p>effective-memory scaffold is up.</p>
+      <p>
+        <Link href="/import">Go to manual review CSV import</Link>
+      </p>
     </main>
   );
 }

--- a/lib/csv.ts
+++ b/lib/csv.ts
@@ -1,0 +1,70 @@
+export type ParsedCsvRow = {
+  rating: string;
+  text: string;
+  reviewed_at: string;
+  author_name?: string;
+};
+
+function parseCsvLine(line: string): string[] {
+  const out: string[] = [];
+  let cur = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        cur += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (ch === "," && !inQuotes) {
+      out.push(cur);
+      cur = "";
+      continue;
+    }
+
+    cur += ch;
+  }
+
+  out.push(cur);
+  return out;
+}
+
+export function parseCsv(text: string): ParsedCsvRow[] {
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (lines.length === 0) return [];
+
+  const headers = parseCsvLine(lines[0]).map((h) => h.trim().toLowerCase());
+  const idx = {
+    rating: headers.indexOf("rating"),
+    text: headers.indexOf("text"),
+    reviewed_at: headers.indexOf("reviewed_at"),
+    author_name: headers.indexOf("author_name")
+  };
+
+  if (idx.rating < 0 || idx.text < 0 || idx.reviewed_at < 0) {
+    throw new Error("CSV must include: rating, text, reviewed_at");
+  }
+
+  const rows: ParsedCsvRow[] = [];
+  for (const rawLine of lines.slice(1)) {
+    const cols = parseCsvLine(rawLine);
+    rows.push({
+      rating: (cols[idx.rating] ?? "").trim(),
+      text: (cols[idx.text] ?? "").trim(),
+      reviewed_at: (cols[idx.reviewed_at] ?? "").trim(),
+      author_name: idx.author_name >= 0 ? (cols[idx.author_name] ?? "").trim() : undefined
+    });
+  }
+
+  return rows;
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,16 +1,27 @@
 import { Pool, QueryResultRow } from "pg";
 
-const databaseUrl = process.env.DATABASE_URL;
+let poolInstance: Pool | null = null;
 
-if (!databaseUrl) {
-  throw new Error("DATABASE_URL is not set");
+function getPool() {
+  if (poolInstance) return poolInstance;
+
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is not set");
+  }
+
+  poolInstance = new Pool({ connectionString: databaseUrl });
+  return poolInstance;
 }
 
-export const pool = new Pool({ connectionString: databaseUrl });
+export const pool = {
+  connect: () => getPool().connect(),
+  end: () => (poolInstance ? poolInstance.end() : Promise.resolve())
+};
 
 export async function query<T extends QueryResultRow = QueryResultRow>(
   text: string,
   params: unknown[] = []
 ) {
-  return pool.query<T>(text, params);
+  return getPool().query<T>(text, params);
 }


### PR DESCRIPTION
Closes #5

## Summary
- added a manual CSV import UI at `/import` with business creation + selection
- added API endpoints for businesses, reviews listing, and CSV import
- implemented CSV parsing + validation rules:
  - supports `rating`, `text`, `reviewed_at` (required) and `author_name` (optional)
  - trims whitespace
  - skips empty rows
  - rejects rows missing required fields or invalid rating/date
- imports valid rows into `reviews` with `source = "manual"`
- added simple imported reviews list view for selected business

## Acceptance criteria coverage
- business can be created/selected in UI
- uploading valid CSV imports rows and returns imported count summary
- imported reviews are persisted and listed via `/api/reviews` and the import page UI

## Testing notes
- npm run typecheck
- npm run lint
- npm run test
- npm run build