### PR TITLE
feat: extract and rank candidate quotes from reviews (v1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,13 @@ docker compose up --build
 - Supported CSV columns:
   - required: `rating`, `text`, `reviewed_at` (ISO)
   - optional: `author_name`
+
+## Quote selector v1 (deterministic)
+
+- UI page: `/quotes`
+- Runs a deterministic selector for a business and persists top-N quote candidates in `draft_posts`.
+- Heuristics:
+  - prefer 4–5 star reviews
+  - prefer 30–200 character quotes
+  - reject profanity matches
+  - boost keyword matches (`food`, `service`, `clean`, `friendly`, etc.)

--- a/app/api/drafts/route.ts
+++ b/app/api/drafts/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { query } from "../../../lib/db";
+
+export async function GET(req: NextRequest) {
+  const businessId = Number(req.nextUrl.searchParams.get("businessId"));
+  if (!Number.isInteger(businessId) || businessId <= 0) {
+    return NextResponse.json({ error: "valid businessId is required" }, { status: 400 });
+  }
+
+  const result = await query<{
+    id: number;
+    review_id: number | null;
+    quote_text: string;
+    status: string;
+    created_at: string;
+  }>(
+    `SELECT id, review_id, quote_text, status, created_at::text
+     FROM draft_posts
+     WHERE business_id = $1
+     ORDER BY created_at DESC, id DESC
+     LIMIT 100`,
+    [businessId]
+  );
+
+  return NextResponse.json({ drafts: result.rows });
+}

--- a/app/api/quotes/select/route.ts
+++ b/app/api/quotes/select/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+import { selectQuoteCandidates } from "../../../../lib/services/quoteSelector";
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const businessId = Number(body?.businessId);
+  const limit = Number(body?.limit ?? 5);
+
+  if (!Number.isInteger(businessId) || businessId <= 0) {
+    return NextResponse.json({ error: "valid businessId is required" }, { status: 400 });
+  }
+
+  if (!Number.isInteger(limit) || limit <= 0 || limit > 25) {
+    return NextResponse.json({ error: "limit must be an integer between 1 and 25" }, { status: 400 });
+  }
+
+  const candidates = await selectQuoteCandidates(businessId, limit);
+  return NextResponse.json({ inserted: candidates.length, candidates });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,9 +5,10 @@ export default function HomePage() {
     <main style={{ padding: 24, fontFamily: "sans-serif" }}>
       <h1>hello</h1>
       <p>effective-memory scaffold is up.</p>
-      <p>
-        <Link href="/import">Go to manual review CSV import</Link>
-      </p>
+      <ul>
+        <li><Link href="/import">Manual review CSV import</Link></li>
+        <li><Link href="/quotes">Quote selector v1</Link></li>
+      </ul>
     </main>
   );
 }

--- a/app/quotes/page.tsx
+++ b/app/quotes/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type Business = { id: number; name: string };
+type Draft = { id: number; review_id: number | null; quote_text: string; status: string };
+
+export default function QuotesPage() {
+  const [businesses, setBusinesses] = useState<Business[]>([]);
+  const [businessId, setBusinessId] = useState("");
+  const [limit, setLimit] = useState(5);
+  const [message, setMessage] = useState("");
+  const [drafts, setDrafts] = useState<Draft[]>([]);
+
+  async function loadBusinesses() {
+    const res = await fetch("/api/businesses");
+    const data = await res.json();
+    setBusinesses(data.businesses ?? []);
+  }
+
+  async function loadDrafts(id: string) {
+    if (!id) return setDrafts([]);
+    const res = await fetch(`/api/drafts?businessId=${id}`);
+    const data = await res.json();
+    setDrafts(data.drafts ?? []);
+  }
+
+  useEffect(() => { loadBusinesses(); }, []);
+  useEffect(() => { loadDrafts(businessId); }, [businessId]);
+
+  async function runSelector() {
+    if (!businessId) return;
+    const res = await fetch("/api/quotes/select", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ businessId: Number(businessId), limit })
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      setMessage(`Selector failed: ${data.error ?? "unknown error"}`);
+      return;
+    }
+    setMessage(`Inserted ${data.inserted} quote candidates`);
+    await loadDrafts(businessId);
+  }
+
+  return (
+    <main style={{ fontFamily: "sans-serif", padding: 24, maxWidth: 960 }}>
+      <h1>Quote selector v1</h1>
+      <p>Deterministic ranking (no AI): rating, length, profanity filter, keywords.</p>
+
+      <section style={{ marginBottom: 16 }}>
+        <select value={businessId} onChange={(e) => setBusinessId(e.target.value)}>
+          <option value="">Select business…</option>
+          {businesses.map((b) => (
+            <option key={b.id} value={b.id}>{b.name}</option>
+          ))}
+        </select>
+
+        <input
+          type="number"
+          min={1}
+          max={25}
+          value={limit}
+          onChange={(e) => setLimit(Number(e.target.value) || 5)}
+          style={{ width: 80, marginLeft: 8 }}
+        />
+
+        <button onClick={runSelector} disabled={!businessId} style={{ marginLeft: 8 }}>
+          Generate candidates
+        </button>
+      </section>
+
+      {message ? <p><strong>{message}</strong></p> : null}
+
+      <section>
+        <h2>Persisted candidates (draft_posts)</h2>
+        <ul>
+          {drafts.map((d) => (
+            <li key={d.id}>#{d.id} [{d.status}] {d.quote_text}</li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/lib/services/quoteSelector.ts
+++ b/lib/services/quoteSelector.ts
@@ -1,0 +1,79 @@
+import { query } from "../db";
+
+type ReviewRow = {
+  id: number;
+  business_id: number;
+  rating: number;
+  text: string;
+};
+
+const PROFANITY = ["fuck", "shit", "bitch", "asshole"];
+const KEYWORDS = ["food", "service", "clean", "friendly", "staff", "delicious", "fresh"];
+
+function containsProfanity(text: string): boolean {
+  const lower = text.toLowerCase();
+  return PROFANITY.some((w) => lower.includes(w));
+}
+
+function keywordScore(text: string): number {
+  const lower = text.toLowerCase();
+  return KEYWORDS.reduce((acc, w) => acc + (lower.includes(w) ? 1 : 0), 0);
+}
+
+function scoreReview(r: ReviewRow): number {
+  const trimmed = r.text.trim();
+  const len = trimmed.length;
+
+  let score = 0;
+  if (r.rating >= 4) score += 50 + r.rating;
+  if (len >= 30 && len <= 200) score += 30;
+  else if (len > 200 && len <= 280) score += 8;
+  score += keywordScore(trimmed) * 10;
+  if (containsProfanity(trimmed)) score -= 200;
+  return score;
+}
+
+export async function selectQuoteCandidates(businessId: number, limit = 5) {
+  const reviews = await query<ReviewRow>(
+    `SELECT id, business_id, rating, text
+     FROM reviews
+     WHERE business_id = $1
+     ORDER BY reviewed_at DESC, id DESC
+     LIMIT 300`,
+    [businessId]
+  );
+
+  const ranked = reviews.rows
+    .map((r) => ({
+      review: r,
+      quoteText: r.text.trim().replace(/\s+/g, " "),
+      score: scoreReview(r)
+    }))
+    .filter((x) => x.review.rating >= 4)
+    .filter((x) => x.quoteText.length >= 30)
+    .filter((x) => !containsProfanity(x.quoteText))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+
+  const inserted: Array<{ draftPostId: number; reviewId: number; quoteText: string; score: number }> = [];
+
+  for (const item of ranked) {
+    // Using draft_posts for persistence keeps MVP schema simple and avoids introducing
+    // a separate candidate table before approval/publishing flow is wired.
+    const res = await query<{ id: number }>(
+      `INSERT INTO draft_posts (business_id, review_id, quote_text, caption_text, status)
+       VALUES ($1, $2, $3, '', 'draft')
+       RETURNING id`,
+      [businessId, item.review.id, item.quoteText]
+    );
+
+    inserted.push({
+      draftPostId: res.rows[0].id,
+      reviewId: item.review.id,
+      quoteText: item.quoteText,
+      score: item.score
+    });
+  }
+
+  return inserted;
+}


### PR DESCRIPTION
Closes #6

## Summary
- added a deterministic quote selector service (`lib/services/quoteSelector.ts`) for a `business_id` and top-N candidates
- implemented v1 heuristics (no AI):
  - prefer 4–5 star reviews
  - prefer 30–200 chars
  - reject profanity list matches
  - prefer keyword mentions (`food`, `service`, `clean`, `friendly`, etc.)
- persisted selected candidates in `draft_posts` as quote-only drafts
- added API endpoint to run selector: `POST /api/quotes/select`
- added API endpoint to view persisted candidates: `GET /api/drafts?businessId=...`
- added simple UI page `/quotes` to run selector and view persisted candidates

## Persistence choice note
Used `draft_posts` (instead of a separate table) to keep MVP schema simple and aligned with downstream approval/scheduling flow.

## Acceptance criteria coverage
- running selector for a business returns top N candidates
- candidates are persisted and visible via API/UI

## Testing notes
- npm run typecheck
- npm run lint
- npm run test
- npm run build