### PR TITLE
feat(ai): generate caption variants for a quote (brand voice v1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ docker compose up --build
   - required: `rating`, `text`, `reviewed_at` (ISO)
   - optional: `author_name`
 
-## Quote selector v1 (deterministic)
+## Quote selector v1 (deterministic) + caption generation
 
 - UI page: `/quotes`
 - Runs a deterministic selector for a business and persists top-N quote candidates in `draft_posts`.
@@ -46,3 +46,5 @@ docker compose up --build
   - prefer 30–200 character quotes
   - reject profanity matches
   - boost keyword matches (`food`, `service`, `clean`, `friendly`, etc.)
+- Caption generation endpoint returns 3 AI variants (`friendly`, `premium`, `playful`) and lets you save selected caption to `draft_posts.caption_text`.
+- Requires `OPENAI_API_KEY` in environment for caption generation.

--- a/app/api/captions/generate/route.ts
+++ b/app/api/captions/generate/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { query } from "../../../../lib/db";
+import { generateCaptionVariants } from "../../../../lib/services/captions";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const draftPostId = Number(body?.draftPostId);
+
+    if (!Number.isInteger(draftPostId) || draftPostId <= 0) {
+      return NextResponse.json({ error: "valid draftPostId is required" }, { status: 400 });
+    }
+
+    const draftRes = await query<{
+      id: number;
+      quote_text: string;
+      business_name: string;
+    }>(
+      `SELECT d.id, d.quote_text, b.name AS business_name
+       FROM draft_posts d
+       JOIN businesses b ON b.id = d.business_id
+       WHERE d.id = $1
+       LIMIT 1`,
+      [draftPostId]
+    );
+
+    if (!draftRes.rowCount) {
+      return NextResponse.json({ error: "draft post not found" }, { status: 404 });
+    }
+
+    const row = draftRes.rows[0];
+    const captions = await generateCaptionVariants({
+      businessName: row.business_name,
+      quoteText: row.quote_text
+    });
+
+    return NextResponse.json({ captions });
+  } catch (err) {
+    // minimal logging without secrets/prompts
+    console.error("caption_generation_failed", err instanceof Error ? err.message : String(err));
+    return NextResponse.json({ error: "caption generation failed" }, { status: 500 });
+  }
+}

--- a/app/api/drafts/caption/route.ts
+++ b/app/api/drafts/caption/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { query } from "../../../../lib/db";
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const draftPostId = Number(body?.draftPostId);
+  const captionText = String(body?.captionText ?? "").trim();
+
+  if (!Number.isInteger(draftPostId) || draftPostId <= 0) {
+    return NextResponse.json({ error: "valid draftPostId is required" }, { status: 400 });
+  }
+
+  if (!captionText) {
+    return NextResponse.json({ error: "captionText is required" }, { status: 400 });
+  }
+
+  if (captionText.length > 200) {
+    return NextResponse.json({ error: "captionText must be <= 200 chars" }, { status: 400 });
+  }
+
+  const result = await query<{ id: number; caption_text: string }>(
+    `UPDATE draft_posts
+     SET caption_text = $2, updated_at = NOW()
+     WHERE id = $1
+     RETURNING id, caption_text`,
+    [draftPostId, captionText]
+  );
+
+  if (!result.rowCount) {
+    return NextResponse.json({ error: "draft post not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ draft: result.rows[0] });
+}

--- a/app/api/drafts/route.ts
+++ b/app/api/drafts/route.ts
@@ -11,10 +11,11 @@ export async function GET(req: NextRequest) {
     id: number;
     review_id: number | null;
     quote_text: string;
+    caption_text: string;
     status: string;
     created_at: string;
   }>(
-    `SELECT id, review_id, quote_text, status, created_at::text
+    `SELECT id, review_id, quote_text, caption_text, status, created_at::text
      FROM draft_posts
      WHERE business_id = $1
      ORDER BY created_at DESC, id DESC

--- a/app/quotes/page.tsx
+++ b/app/quotes/page.tsx
@@ -3,7 +3,14 @@
 import { useEffect, useState } from "react";
 
 type Business = { id: number; name: string };
-type Draft = { id: number; review_id: number | null; quote_text: string; status: string };
+type Draft = {
+  id: number;
+  review_id: number | null;
+  quote_text: string;
+  caption_text: string;
+  status: string;
+};
+type CaptionSet = { friendly: string; premium: string; playful: string };
 
 export default function QuotesPage() {
   const [businesses, setBusinesses] = useState<Business[]>([]);
@@ -11,6 +18,8 @@ export default function QuotesPage() {
   const [limit, setLimit] = useState(5);
   const [message, setMessage] = useState("");
   const [drafts, setDrafts] = useState<Draft[]>([]);
+  const [captionVariantsByDraft, setCaptionVariantsByDraft] = useState<Record<number, CaptionSet>>({});
+  const [loadingDraftId, setLoadingDraftId] = useState<number | null>(null);
 
   async function loadBusinesses() {
     const res = await fetch("/api/businesses");
@@ -25,8 +34,12 @@ export default function QuotesPage() {
     setDrafts(data.drafts ?? []);
   }
 
-  useEffect(() => { loadBusinesses(); }, []);
-  useEffect(() => { loadDrafts(businessId); }, [businessId]);
+  useEffect(() => {
+    loadBusinesses();
+  }, []);
+  useEffect(() => {
+    loadDrafts(businessId);
+  }, [businessId]);
 
   async function runSelector() {
     if (!businessId) return;
@@ -44,16 +57,53 @@ export default function QuotesPage() {
     await loadDrafts(businessId);
   }
 
+  async function generateCaptions(draftPostId: number) {
+    setLoadingDraftId(draftPostId);
+    try {
+      const res = await fetch("/api/captions/generate", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ draftPostId })
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setMessage(`Caption generation failed: ${data.error ?? "unknown error"}`);
+        return;
+      }
+      setCaptionVariantsByDraft((prev) => ({ ...prev, [draftPostId]: data.captions }));
+      setMessage(`Generated caption variants for draft #${draftPostId}`);
+    } finally {
+      setLoadingDraftId(null);
+    }
+  }
+
+  async function chooseCaption(draftPostId: number, captionText: string) {
+    const res = await fetch("/api/drafts/caption", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ draftPostId, captionText })
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      setMessage(`Save caption failed: ${data.error ?? "unknown error"}`);
+      return;
+    }
+    setMessage(`Saved caption to draft #${draftPostId}`);
+    await loadDrafts(businessId);
+  }
+
   return (
     <main style={{ fontFamily: "sans-serif", padding: 24, maxWidth: 960 }}>
-      <h1>Quote selector v1</h1>
-      <p>Deterministic ranking (no AI): rating, length, profanity filter, keywords.</p>
+      <h1>Quote selector + caption generation</h1>
+      <p>Deterministic quote ranking + AI caption variants (friendly/premium/playful).</p>
 
       <section style={{ marginBottom: 16 }}>
         <select value={businessId} onChange={(e) => setBusinessId(e.target.value)}>
           <option value="">Select business…</option>
           {businesses.map((b) => (
-            <option key={b.id} value={b.id}>{b.name}</option>
+            <option key={b.id} value={b.id}>
+              {b.name}
+            </option>
           ))}
         </select>
 
@@ -71,14 +121,56 @@ export default function QuotesPage() {
         </button>
       </section>
 
-      {message ? <p><strong>{message}</strong></p> : null}
+      {message ? (
+        <p>
+          <strong>{message}</strong>
+        </p>
+      ) : null}
 
       <section>
-        <h2>Persisted candidates (draft_posts)</h2>
+        <h2>Persisted draft candidates</h2>
         <ul>
-          {drafts.map((d) => (
-            <li key={d.id}>#{d.id} [{d.status}] {d.quote_text}</li>
-          ))}
+          {drafts.map((d) => {
+            const variants = captionVariantsByDraft[d.id];
+            return (
+              <li key={d.id} style={{ marginBottom: 16 }}>
+                <div>
+                  #{d.id} [{d.status}] {d.quote_text}
+                </div>
+                <div style={{ marginTop: 6 }}>
+                  <button
+                    onClick={() => generateCaptions(d.id)}
+                    disabled={loadingDraftId === d.id}
+                  >
+                    {loadingDraftId === d.id ? "Generating..." : "Generate captions"}
+                  </button>
+                </div>
+
+                {variants ? (
+                  <ul>
+                    {([
+                      ["friendly", variants.friendly],
+                      ["premium", variants.premium],
+                      ["playful", variants.playful]
+                    ] as const).map(([style, text]) => (
+                      <li key={style} style={{ marginTop: 6 }}>
+                        <strong>{style}:</strong> {text}{" "}
+                        <button onClick={() => chooseCaption(d.id, text)} style={{ marginLeft: 8 }}>
+                          Use this
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
+
+                {d.caption_text ? (
+                  <div style={{ marginTop: 6 }}>
+                    <em>Saved caption:</em> {d.caption_text}
+                  </div>
+                ) : null}
+              </li>
+            );
+          })}
         </ul>
       </section>
     </main>

--- a/lib/services/captions.ts
+++ b/lib/services/captions.ts
@@ -1,0 +1,93 @@
+type CaptionStyles = {
+  friendly: string;
+  premium: string;
+  playful: string;
+};
+
+function countHashtags(text: string): number {
+  return (text.match(/(^|\s)#\w+/g) ?? []).length;
+}
+
+function sanitizeCaption(text: string): string {
+  const cleaned = text.replace(/\s+/g, " ").trim();
+  const clipped = cleaned.length > 200 ? `${cleaned.slice(0, 197).trim()}...` : cleaned;
+
+  const words = clipped.split(" ");
+  let seenTags = 0;
+  const limited = words.filter((w) => {
+    if (w.startsWith("#")) {
+      seenTags += 1;
+      return seenTags <= 5;
+    }
+    return true;
+  });
+
+  return limited.join(" ").trim();
+}
+
+export async function generateCaptionVariants(params: {
+  businessName: string;
+  quoteText: string;
+}): Promise<CaptionStyles> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error("OPENAI_API_KEY is not set");
+  }
+
+  const prompt = `You are writing social captions for a local business.
+Business: ${params.businessName}
+Quote: "${params.quoteText}"
+
+Return ONLY JSON with keys friendly, premium, playful.
+Rules:
+- include business name subtly (not spammy)
+- each caption <= 200 chars
+- max 5 hashtags per caption
+- no markdown, no extra keys`;
+
+  const res = await fetch("https://api.openai.com/v1/responses", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model: "gpt-4o-mini",
+      input: prompt,
+      max_output_tokens: 400
+    })
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`OpenAI request failed: ${res.status} ${text.slice(0, 300)}`);
+  }
+
+  const data = (await res.json()) as {
+    output_text?: string;
+  };
+
+  const raw = data.output_text ?? "";
+  let parsed: Partial<CaptionStyles> = {};
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    const match = raw.match(/\{[\s\S]*\}/);
+    if (!match) throw new Error("Failed to parse OpenAI caption JSON");
+    parsed = JSON.parse(match[0]);
+  }
+
+  const friendly = sanitizeCaption(String(parsed.friendly ?? "").trim());
+  const premium = sanitizeCaption(String(parsed.premium ?? "").trim());
+  const playful = sanitizeCaption(String(parsed.playful ?? "").trim());
+
+  const variants = { friendly, premium, playful };
+
+  for (const [style, text] of Object.entries(variants)) {
+    if (!text) throw new Error(`Caption missing for style: ${style}`);
+    if (text.length > 200) throw new Error(`Caption too long for style: ${style}`);
+    if (countHashtags(text) > 5) throw new Error(`Too many hashtags for style: ${style}`);
+  }
+
+  return variants;
+}


### PR DESCRIPTION
Closes #7

## Summary
- added AI caption generation endpoint: `POST /api/captions/generate`
- generates 3 variants for each draft quote: `friendly`, `premium`, `playful`
- enforces caption constraints in service layer:
  - subtle business name inclusion prompt guidance
  - <= 200 chars
  - <= 5 hashtags
- added endpoint to save selected caption to draft post: `POST /api/drafts/caption`
- extended drafts API to include `caption_text`
- updated `/quotes` UI to:
  - generate caption variants per draft
  - preview variants
  - choose/save one variant into `draft_posts.caption_text`
- added minimal failure logging without secrets/prompts

## Acceptance criteria coverage
- user can click “Generate captions” for a quote candidate
- system calls OpenAI and returns 3 variants
- user can pick one variant and save it to draft post

## Testing notes
- npm run typecheck
- npm run lint
- npm run test
- npm run build