### PR TITLE
feat: render branded quote graphic (template v1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ docker compose up --build
   - required: `rating`, `text`, `reviewed_at` (ISO)
   - optional: `author_name`
 
-## Quote selector v1 (deterministic) + caption generation
+## Quote selector v1 (deterministic) + caption generation + image rendering
 
 - UI page: `/quotes`
 - Runs a deterministic selector for a business and persists top-N quote candidates in `draft_posts`.
@@ -47,4 +47,5 @@ docker compose up --build
   - reject profanity matches
   - boost keyword matches (`food`, `service`, `clean`, `friendly`, etc.)
 - Caption generation endpoint returns 3 AI variants (`friendly`, `premium`, `playful`) and lets you save selected caption to `draft_posts.caption_text`.
+- Branded image rendering endpoint generates PNGs in local storage (`public/generated`) and saves path to `draft_posts.image_path`.
 - Requires `OPENAI_API_KEY` in environment for caption generation.

--- a/app/api/drafts/route.ts
+++ b/app/api/drafts/route.ts
@@ -12,10 +12,11 @@ export async function GET(req: NextRequest) {
     review_id: number | null;
     quote_text: string;
     caption_text: string;
+    image_path: string | null;
     status: string;
     created_at: string;
   }>(
-    `SELECT id, review_id, quote_text, caption_text, status, created_at::text
+    `SELECT id, review_id, quote_text, caption_text, image_path, status, created_at::text
      FROM draft_posts
      WHERE business_id = $1
      ORDER BY created_at DESC, id DESC

--- a/app/api/images/render/route.ts
+++ b/app/api/images/render/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+import { query } from "../../../../lib/db";
+import { renderDraftImage } from "../../../../lib/services/imageRenderer";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const draftPostId = Number(body?.draftPostId);
+
+    if (!Number.isInteger(draftPostId) || draftPostId <= 0) {
+      return NextResponse.json({ error: "valid draftPostId is required" }, { status: 400 });
+    }
+
+    const draft = await query<{
+      id: number;
+      quote_text: string;
+      business_name: string;
+      brand_colors: Record<string, string> | null;
+      logo_url: string | null;
+    }>(
+      `SELECT d.id, d.quote_text, b.name AS business_name, b.brand_colors, b.logo_url
+       FROM draft_posts d
+       JOIN businesses b ON b.id = d.business_id
+       WHERE d.id = $1
+       LIMIT 1`,
+      [draftPostId]
+    );
+
+    if (!draft.rowCount) {
+      return NextResponse.json({ error: "draft not found" }, { status: 404 });
+    }
+
+    const row = draft.rows[0];
+    const brandHex = row.brand_colors?.primary ?? null;
+
+    const rendered = await renderDraftImage({
+      draftPostId,
+      businessName: row.business_name,
+      quoteText: row.quote_text,
+      brandHex,
+      logoUrl: row.logo_url
+    });
+
+    const updated = await query<{ id: number; image_path: string }>(
+      `UPDATE draft_posts
+       SET image_path = $2, updated_at = NOW()
+       WHERE id = $1
+       RETURNING id, image_path`,
+      [draftPostId, rendered.publicPath]
+    );
+
+    return NextResponse.json({ draft: updated.rows[0] });
+  } catch (err) {
+    console.error("image_render_failed", err instanceof Error ? err.message : String(err));
+    return NextResponse.json({ error: "render failed" }, { status: 500 });
+  }
+}

--- a/app/quotes/page.tsx
+++ b/app/quotes/page.tsx
@@ -8,6 +8,7 @@ type Draft = {
   review_id: number | null;
   quote_text: string;
   caption_text: string;
+  image_path: string | null;
   status: string;
 };
 type CaptionSet = { friendly: string; premium: string; playful: string };
@@ -20,6 +21,7 @@ export default function QuotesPage() {
   const [drafts, setDrafts] = useState<Draft[]>([]);
   const [captionVariantsByDraft, setCaptionVariantsByDraft] = useState<Record<number, CaptionSet>>({});
   const [loadingDraftId, setLoadingDraftId] = useState<number | null>(null);
+  const [renderingDraftId, setRenderingDraftId] = useState<number | null>(null);
 
   async function loadBusinesses() {
     const res = await fetch("/api/businesses");
@@ -92,10 +94,30 @@ export default function QuotesPage() {
     await loadDrafts(businessId);
   }
 
+  async function renderImage(draftPostId: number) {
+    setRenderingDraftId(draftPostId);
+    try {
+      const res = await fetch("/api/images/render", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ draftPostId })
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setMessage(`Render failed: ${data.error ?? "unknown error"}`);
+        return;
+      }
+      setMessage(`Rendered image for draft #${draftPostId}`);
+      await loadDrafts(businessId);
+    } finally {
+      setRenderingDraftId(null);
+    }
+  }
+
   return (
     <main style={{ fontFamily: "sans-serif", padding: 24, maxWidth: 960 }}>
       <h1>Quote selector + caption generation</h1>
-      <p>Deterministic quote ranking + AI caption variants (friendly/premium/playful).</p>
+      <p>Deterministic quote ranking + AI captions + branded image render.</p>
 
       <section style={{ marginBottom: 16 }}>
         <select value={businessId} onChange={(e) => setBusinessId(e.target.value)}>
@@ -133,7 +155,7 @@ export default function QuotesPage() {
           {drafts.map((d) => {
             const variants = captionVariantsByDraft[d.id];
             return (
-              <li key={d.id} style={{ marginBottom: 16 }}>
+              <li key={d.id} style={{ marginBottom: 20 }}>
                 <div>
                   #{d.id} [{d.status}] {d.quote_text}
                 </div>
@@ -143,6 +165,13 @@ export default function QuotesPage() {
                     disabled={loadingDraftId === d.id}
                   >
                     {loadingDraftId === d.id ? "Generating..." : "Generate captions"}
+                  </button>
+                  <button
+                    onClick={() => renderImage(d.id)}
+                    disabled={renderingDraftId === d.id}
+                    style={{ marginLeft: 8 }}
+                  >
+                    {renderingDraftId === d.id ? "Rendering..." : "Render image"}
                   </button>
                 </div>
 
@@ -166,6 +195,12 @@ export default function QuotesPage() {
                 {d.caption_text ? (
                   <div style={{ marginTop: 6 }}>
                     <em>Saved caption:</em> {d.caption_text}
+                  </div>
+                ) : null}
+
+                {d.image_path ? (
+                  <div style={{ marginTop: 8 }}>
+                    <img src={d.image_path} alt={`Draft ${d.id} graphic`} style={{ width: 240, border: "1px solid #ddd" }} />
                   </div>
                 ) : null}
               </li>

--- a/db/migrations/002_add_image_path_to_draft_posts.sql
+++ b/db/migrations/002_add_image_path_to_draft_posts.sql
@@ -1,0 +1,2 @@
+ALTER TABLE draft_posts
+ADD COLUMN IF NOT EXISTS image_path TEXT;

--- a/lib/services/imageRenderer.ts
+++ b/lib/services/imageRenderer.ts
@@ -1,0 +1,54 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import sharp from "sharp";
+
+function esc(text: string): string {
+  return text
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+export async function renderDraftImage(params: {
+  draftPostId: number;
+  businessName: string;
+  quoteText: string;
+  brandHex?: string | null;
+  logoUrl?: string | null;
+}) {
+  const width = 1080;
+  const height = 1080;
+  const bg = params.brandHex && /^#?[0-9a-fA-F]{6}$/.test(params.brandHex)
+    ? (params.brandHex.startsWith("#") ? params.brandHex : `#${params.brandHex}`)
+    : "#1f2937";
+
+  const business = esc(params.businessName);
+  const quote = esc(params.quoteText);
+  const logoBlock = params.logoUrl
+    ? `<text x="80" y="180" fill="#ffffff" font-size="28" font-family="Arial">logo: ${esc(params.logoUrl)}</text>`
+    : "";
+
+  const svg = `
+  <svg width="${width}" height="${height}" xmlns="http://www.w3.org/2000/svg">
+    <rect width="100%" height="100%" fill="${bg}" />
+    <text x="80" y="100" fill="#ffffff" font-size="46" font-weight="700" font-family="Arial">${business}</text>
+    ${logoBlock}
+    <foreignObject x="80" y="250" width="920" height="680">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="font-family:Arial,sans-serif;color:#ffffff;font-size:48px;line-height:1.25;">
+        “${quote}”
+      </div>
+    </foreignObject>
+  </svg>`;
+
+  const outDir = join(process.cwd(), "public", "generated");
+  mkdirSync(outDir, { recursive: true });
+  const filename = `draft-${params.draftPostId}.png`;
+  const outPath = join(outDir, filename);
+
+  const png = await sharp(Buffer.from(svg)).png({ quality: 90 }).toBuffer();
+  writeFileSync(outPath, png);
+
+  return { fileSystemPath: outPath, publicPath: `/generated/${filename}` };
+}


### PR DESCRIPTION
Closes #8

## Summary
- added branded image render endpoint for draft posts: `POST /api/images/render`
- added renderer service that creates a minimal template PNG with:
  - brand-color background
  - business name
  - quote text
  - optional logo text marker when logo URL exists
- stores generated files in local storage (`public/generated/...png`)
- persists generated image path in `draft_posts.image_path`
- added migration `002_add_image_path_to_draft_posts.sql`
- updated drafts API + `/quotes` UI to render image previews

## Testing notes
- npm run typecheck
- npm run lint
- npm run test
- npm run build