### PR TITLE
feat: approval queue for draft posts (draft → approved)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,12 @@ docker compose up --build
 - Caption generation endpoint returns 3 AI variants (`friendly`, `premium`, `playful`) and lets you save selected caption to `draft_posts.caption_text`.
 - Branded image rendering endpoint generates PNGs in local storage (`public/generated`) and saves path to `draft_posts.image_path`.
 - Requires `OPENAI_API_KEY` in environment for caption generation.
+
+## Approval queue
+
+- UI page: `/approval`
+- Lists draft posts grouped by status (`draft`, `approved`)
+- Supports transitions:
+  - draft -> approved
+  - approved -> draft
+- Persists optional `audit_note` and updates `updated_at` on each transition.

--- a/app/api/drafts/route.ts
+++ b/app/api/drafts/route.ts
@@ -14,9 +14,10 @@ export async function GET(req: NextRequest) {
     caption_text: string;
     image_path: string | null;
     status: string;
+    audit_note: string | null;
     created_at: string;
   }>(
-    `SELECT id, review_id, quote_text, caption_text, image_path, status, created_at::text
+    `SELECT id, review_id, quote_text, caption_text, image_path, status, audit_note, created_at::text
      FROM draft_posts
      WHERE business_id = $1
      ORDER BY created_at DESC, id DESC

--- a/app/api/drafts/status/route.ts
+++ b/app/api/drafts/status/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { query } from "../../../../lib/db";
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const draftPostId = Number(body?.draftPostId);
+  const status = String(body?.status ?? "").trim();
+  const auditNote = String(body?.auditNote ?? "").trim() || null;
+
+  if (!Number.isInteger(draftPostId) || draftPostId <= 0) {
+    return NextResponse.json({ error: "valid draftPostId is required" }, { status: 400 });
+  }
+
+  if (!["draft", "approved"].includes(status)) {
+    return NextResponse.json({ error: "status must be draft or approved" }, { status: 400 });
+  }
+
+  const result = await query<{
+    id: number;
+    status: string;
+    audit_note: string | null;
+    updated_at: string;
+  }>(
+    `UPDATE draft_posts
+     SET status = $2,
+         audit_note = $3,
+         updated_at = NOW()
+     WHERE id = $1
+     RETURNING id, status, audit_note, updated_at::text`,
+    [draftPostId, status, auditNote]
+  );
+
+  if (!result.rowCount) {
+    return NextResponse.json({ error: "draft post not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ draft: result.rows[0] });
+}

--- a/app/approval/page.tsx
+++ b/app/approval/page.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type Business = { id: number; name: string };
+type Draft = {
+  id: number;
+  review_id: number | null;
+  quote_text: string;
+  caption_text: string;
+  image_path: string | null;
+  status: string;
+  audit_note?: string | null;
+  created_at: string;
+};
+
+export default function ApprovalPage() {
+  const [businesses, setBusinesses] = useState<Business[]>([]);
+  const [businessId, setBusinessId] = useState("");
+  const [drafts, setDrafts] = useState<Draft[]>([]);
+  const [message, setMessage] = useState("");
+  const [notes, setNotes] = useState<Record<number, string>>({});
+
+  async function loadBusinesses() {
+    const res = await fetch("/api/businesses");
+    const data = await res.json();
+    setBusinesses(data.businesses ?? []);
+  }
+
+  async function loadDrafts(id: string) {
+    if (!id) return setDrafts([]);
+    const res = await fetch(`/api/drafts?businessId=${id}`);
+    const data = await res.json();
+    setDrafts(data.drafts ?? []);
+  }
+
+  useEffect(() => {
+    loadBusinesses();
+  }, []);
+
+  useEffect(() => {
+    loadDrafts(businessId);
+  }, [businessId]);
+
+  const byStatus = useMemo(() => {
+    return {
+      draft: drafts.filter((d) => d.status === "draft"),
+      approved: drafts.filter((d) => d.status === "approved")
+    };
+  }, [drafts]);
+
+  async function updateStatus(draftPostId: number, status: "draft" | "approved") {
+    const res = await fetch("/api/drafts/status", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        draftPostId,
+        status,
+        auditNote: notes[draftPostId] ?? ""
+      })
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      setMessage(`Status update failed: ${data.error ?? "unknown error"}`);
+      return;
+    }
+
+    setMessage(`Draft #${draftPostId} moved to ${status}`);
+    await loadDrafts(businessId);
+  }
+
+  return (
+    <main style={{ fontFamily: "sans-serif", padding: 24, maxWidth: 1100 }}>
+      <h1>Draft approval queue</h1>
+
+      <section style={{ marginBottom: 16 }}>
+        <select value={businessId} onChange={(e) => setBusinessId(e.target.value)}>
+          <option value="">Select business…</option>
+          {businesses.map((b) => (
+            <option key={b.id} value={b.id}>
+              {b.name}
+            </option>
+          ))}
+        </select>
+      </section>
+
+      {message ? (
+        <p>
+          <strong>{message}</strong>
+        </p>
+      ) : null}
+
+      <section style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
+        <div>
+          <h2>Draft</h2>
+          <ul>
+            {byStatus.draft.map((d) => (
+              <li key={d.id} style={{ marginBottom: 14 }}>
+                <div>#{d.id} {d.quote_text}</div>
+                <input
+                  placeholder="audit note (optional)"
+                  value={notes[d.id] ?? ""}
+                  onChange={(e) => setNotes((prev) => ({ ...prev, [d.id]: e.target.value }))}
+                  style={{ width: 260, marginTop: 4 }}
+                />
+                <div>
+                  <button onClick={() => updateStatus(d.id, "approved")} style={{ marginTop: 6 }}>
+                    Approve
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div>
+          <h2>Approved</h2>
+          <ul>
+            {byStatus.approved.map((d) => (
+              <li key={d.id} style={{ marginBottom: 14 }}>
+                <div>#{d.id} {d.quote_text}</div>
+                <input
+                  placeholder="audit note (optional)"
+                  value={notes[d.id] ?? ""}
+                  onChange={(e) => setNotes((prev) => ({ ...prev, [d.id]: e.target.value }))}
+                  style={{ width: 260, marginTop: 4 }}
+                />
+                <div>
+                  <button onClick={() => updateStatus(d.id, "draft")} style={{ marginTop: 6 }}>
+                    Send back to draft
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ export default function HomePage() {
       <ul>
         <li><Link href="/import">Manual review CSV import</Link></li>
         <li><Link href="/quotes">Quote selector v1</Link></li>
+        <li><Link href="/approval">Draft approval queue</Link></li>
       </ul>
     </main>
   );

--- a/db/migrations/003_add_audit_note_to_draft_posts.sql
+++ b/db/migrations/003_add_audit_note_to_draft_posts.sql
@@ -1,0 +1,2 @@
+ALTER TABLE draft_posts
+ADD COLUMN IF NOT EXISTS audit_note TEXT;


### PR DESCRIPTION
Closes #9

## Summary
- added approval status endpoint: `POST /api/drafts/status`
- supports transitions:
  - `draft` -> `approved`
  - `approved` -> `draft`
- updates `updated_at` on every status transition
- added optional `audit_note` persistence via migration `003_add_audit_note_to_draft_posts.sql`
- extended drafts API to return `audit_note`
- added approval UI page `/approval` with grouped lists and action buttons
- linked approval page from home screen

## Acceptance criteria coverage
- draft posts can be approved in UI
- approved posts appear in approved list
- status transitions are persisted and survive restarts

## Testing notes
- npm run typecheck
- npm run lint
- npm run test
- npm run build