### PR TITLE
feat: scheduling integration (stub) for approved posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,17 @@ docker compose up --build
 ## Approval queue
 
 - UI page: `/approval`
-- Lists draft posts grouped by status (`draft`, `approved`)
+- Lists draft posts grouped by status (`draft`, `approved`, `scheduled`)
 - Supports transitions:
   - draft -> approved
   - approved -> draft
+- Supports setting `scheduled_for` datetime for approved drafts.
 - Persists optional `audit_note` and updates `updated_at` on each transition.
+
+## Scheduling (stub adapter)
+
+- Scheduler adapter interface: `lib/integrations/scheduler.ts`
+- Stub implementation logs structured scheduling payload and returns `scheduled`.
+- Worker command: `npm run worker:schedule`
+  - picks up rows with `status='approved'` and due `scheduled_for`
+  - marks rows `status='scheduled'` after adapter call

--- a/app/api/drafts/route.ts
+++ b/app/api/drafts/route.ts
@@ -15,9 +15,10 @@ export async function GET(req: NextRequest) {
     image_path: string | null;
     status: string;
     audit_note: string | null;
+    scheduled_for: string | null;
     created_at: string;
   }>(
-    `SELECT id, review_id, quote_text, caption_text, image_path, status, audit_note, created_at::text
+    `SELECT id, review_id, quote_text, caption_text, image_path, status, audit_note, scheduled_for::text, created_at::text
      FROM draft_posts
      WHERE business_id = $1
      ORDER BY created_at DESC, id DESC

--- a/app/api/drafts/schedule/route.ts
+++ b/app/api/drafts/schedule/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { query } from "../../../../lib/db";
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const draftPostId = Number(body?.draftPostId);
+  const scheduledFor = String(body?.scheduledFor ?? "").trim();
+
+  if (!Number.isInteger(draftPostId) || draftPostId <= 0) {
+    return NextResponse.json({ error: "valid draftPostId is required" }, { status: 400 });
+  }
+
+  const when = new Date(scheduledFor);
+  if (!scheduledFor || Number.isNaN(when.getTime())) {
+    return NextResponse.json({ error: "valid scheduledFor datetime is required" }, { status: 400 });
+  }
+
+  const result = await query<{
+    id: number;
+    status: string;
+    scheduled_for: string;
+  }>(
+    `UPDATE draft_posts
+     SET scheduled_for = $2,
+         status = CASE WHEN status = 'approved' THEN 'approved' ELSE status END,
+         updated_at = NOW()
+     WHERE id = $1
+     RETURNING id, status, scheduled_for::text`,
+    [draftPostId, when.toISOString()]
+  );
+
+  if (!result.rowCount) {
+    return NextResponse.json({ error: "draft post not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ draft: result.rows[0] });
+}

--- a/app/approval/page.tsx
+++ b/app/approval/page.tsx
@@ -11,6 +11,7 @@ type Draft = {
   image_path: string | null;
   status: string;
   audit_note?: string | null;
+  scheduled_for?: string | null;
   created_at: string;
 };
 
@@ -20,6 +21,7 @@ export default function ApprovalPage() {
   const [drafts, setDrafts] = useState<Draft[]>([]);
   const [message, setMessage] = useState("");
   const [notes, setNotes] = useState<Record<number, string>>({});
+  const [scheduledForByDraft, setScheduledForByDraft] = useState<Record<number, string>>({});
 
   async function loadBusinesses() {
     const res = await fetch("/api/businesses");
@@ -45,7 +47,8 @@ export default function ApprovalPage() {
   const byStatus = useMemo(() => {
     return {
       draft: drafts.filter((d) => d.status === "draft"),
-      approved: drafts.filter((d) => d.status === "approved")
+      approved: drafts.filter((d) => d.status === "approved"),
+      scheduled: drafts.filter((d) => d.status === "scheduled")
     };
   }, [drafts]);
 
@@ -66,6 +69,29 @@ export default function ApprovalPage() {
     }
 
     setMessage(`Draft #${draftPostId} moved to ${status}`);
+    await loadDrafts(businessId);
+  }
+
+  async function setSchedule(draftPostId: number) {
+    const scheduledFor = scheduledForByDraft[draftPostId];
+    if (!scheduledFor) {
+      setMessage("Please choose a datetime first");
+      return;
+    }
+
+    const iso = new Date(scheduledFor).toISOString();
+    const res = await fetch("/api/drafts/schedule", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ draftPostId, scheduledFor: iso })
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      setMessage(`Schedule set failed: ${data.error ?? "unknown error"}`);
+      return;
+    }
+
+    setMessage(`Scheduled time set for draft #${draftPostId}`);
     await loadDrafts(businessId);
   }
 
@@ -90,7 +116,7 @@ export default function ApprovalPage() {
         </p>
       ) : null}
 
-      <section style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
+      <section style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 16 }}>
         <div>
           <h2>Draft</h2>
           <ul>
@@ -120,15 +146,34 @@ export default function ApprovalPage() {
               <li key={d.id} style={{ marginBottom: 14 }}>
                 <div>#{d.id} {d.quote_text}</div>
                 <input
-                  placeholder="audit note (optional)"
-                  value={notes[d.id] ?? ""}
-                  onChange={(e) => setNotes((prev) => ({ ...prev, [d.id]: e.target.value }))}
-                  style={{ width: 260, marginTop: 4 }}
+                  type="datetime-local"
+                  value={scheduledForByDraft[d.id] ?? ""}
+                  onChange={(e) =>
+                    setScheduledForByDraft((prev) => ({ ...prev, [d.id]: e.target.value }))
+                  }
+                  style={{ marginTop: 4 }}
                 />
                 <div>
-                  <button onClick={() => updateStatus(d.id, "draft")} style={{ marginTop: 6 }}>
+                  <button onClick={() => setSchedule(d.id)} style={{ marginTop: 6 }}>
+                    Set schedule
+                  </button>
+                  <button onClick={() => updateStatus(d.id, "draft")} style={{ marginTop: 6, marginLeft: 8 }}>
                     Send back to draft
                   </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div>
+          <h2>Scheduled</h2>
+          <ul>
+            {byStatus.scheduled.map((d) => (
+              <li key={d.id} style={{ marginBottom: 14 }}>
+                <div>#{d.id} {d.quote_text}</div>
+                <div>
+                  <small>scheduled_for: {d.scheduled_for ?? "(none)"}</small>
                 </div>
               </li>
             ))}

--- a/lib/integrations/scheduler.ts
+++ b/lib/integrations/scheduler.ts
@@ -1,0 +1,30 @@
+export type SchedulePayload = {
+  draftPostId: number;
+  businessId: number;
+  quoteText: string;
+  captionText: string;
+  imagePath: string | null;
+  scheduledFor: string;
+};
+
+export interface SchedulerAdapter {
+  schedulePost(payload: SchedulePayload): Promise<{ externalId?: string; status: "scheduled" }>;
+}
+
+export class StubSchedulerAdapter implements SchedulerAdapter {
+  async schedulePost(payload: SchedulePayload): Promise<{ externalId?: string; status: "scheduled" }> {
+    // Structured logging for MVP observability without external integration.
+    console.log(
+      JSON.stringify({
+        event: "scheduler.stub.schedule_post",
+        payload
+      })
+    );
+
+    return { status: "scheduled", externalId: `stub-${payload.draftPostId}` };
+  }
+}
+
+export function getSchedulerAdapter(): SchedulerAdapter {
+  return new StubSchedulerAdapter();
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "typecheck": "tsc --noEmit",
     "test": "echo 'test placeholder'",
     "db:migrate": "npx ts-node scripts/migrate.ts",
-    "db:health": "npx ts-node scripts/db-health.ts"
+    "db:health": "npx ts-node scripts/db-health.ts",
+    "worker:schedule": "npx ts-node scripts/schedule-worker.ts"
   },
   "dependencies": {
     "next": "15.5.10",

--- a/scripts/schedule-worker.ts
+++ b/scripts/schedule-worker.ts
@@ -1,0 +1,56 @@
+import { query, pool } from "../lib/db";
+import { getSchedulerAdapter } from "../lib/integrations/scheduler";
+
+async function runOnce() {
+  const adapter = getSchedulerAdapter();
+
+  const rows = await query<{
+    id: number;
+    business_id: number;
+    quote_text: string;
+    caption_text: string;
+    image_path: string | null;
+    scheduled_for: string;
+  }>(
+    `SELECT id, business_id, quote_text, caption_text, image_path, scheduled_for::text
+     FROM draft_posts
+     WHERE status = 'approved'
+       AND scheduled_for IS NOT NULL
+       AND scheduled_for <= NOW()
+     ORDER BY scheduled_for ASC
+     LIMIT 25`
+  );
+
+  let scheduledCount = 0;
+
+  for (const row of rows.rows) {
+    await adapter.schedulePost({
+      draftPostId: row.id,
+      businessId: row.business_id,
+      quoteText: row.quote_text,
+      captionText: row.caption_text,
+      imagePath: row.image_path,
+      scheduledFor: row.scheduled_for
+    });
+
+    await query(
+      `UPDATE draft_posts
+       SET status = 'scheduled', updated_at = NOW()
+       WHERE id = $1`,
+      [row.id]
+    );
+
+    scheduledCount += 1;
+  }
+
+  console.log(JSON.stringify({ event: "scheduler.stub.run_complete", scheduledCount }));
+}
+
+runOnce()
+  .catch((err) => {
+    console.error("scheduler_stub_failed", err instanceof Error ? err.message : String(err));
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await pool.end();
+  });


### PR DESCRIPTION
Closes #10

## Summary
- added scheduling datetime input for approved drafts on `/approval`
- added scheduling endpoint: `POST /api/drafts/schedule`
- added scheduler adapter interface + stub implementation in `lib/integrations/scheduler.ts`
- added worker job script `scripts/schedule-worker.ts` and npm script `worker:schedule`
- worker picks up `approved + scheduled_for <= now` drafts and schedules via stub adapter
- worker marks scheduled drafts as `status='scheduled'`
- stub adapter logs structured scheduling payload for observability

## Acceptance criteria coverage
- user can set scheduled time for approved posts
- worker marks status as `scheduled`
- scheduling payload is logged in structured JSON

## Testing notes
- npm run typecheck
- npm run lint
- npm run test
- npm run build
