### PR TITLE
feat: automate draft generation pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ docker compose up --build
 - Supports setting `scheduled_for` datetime for approved drafts.
 - Persists optional `audit_note` and updates `updated_at` on each transition.
 
+## Draft generation worker
+
+- Worker entrypoint: `worker/index.ts`
+- Automatically runs quote selection -> caption generation -> image render for each business on a timer.
+- New draft candidates are created in `draft_posts` with:
+  - `quote_text` from selector
+  - `caption_text` from caption generator (friendly variant)
+  - `image_path` from renderer output
+- Duplicates are avoided by skipping reviews already linked to an existing draft.
+
 ## Scheduling (stub adapter)
 
 - Scheduler adapter interface: `lib/integrations/scheduler.ts`

--- a/lib/services/draftPipeline.ts
+++ b/lib/services/draftPipeline.ts
@@ -1,0 +1,149 @@
+import { renderDraftImage } from "./imageRenderer";
+import { selectQuoteCandidates } from "./quoteSelector";
+import { generateCaptionVariants } from "./captions";
+import { query } from "../db";
+
+type BusinessRow = {
+  id: number;
+  name: string;
+  brand_colors: Record<string, string> | null;
+  logo_url: string | null;
+};
+
+type CandidateRow = {
+  draftPostId: number;
+  reviewId: number;
+  quoteText: string;
+  score: number;
+};
+
+type CaptionSet = { friendly: string; premium: string; playful: string };
+
+type PipelineOptions = {
+  perBusinessLimit?: number;
+};
+
+export type PipelineResult = {
+  businessesScanned: number;
+  candidatesInserted: number;
+  draftsCompleted: number;
+  draftsFailed: number;
+};
+
+type DraftPipelineDeps = {
+  listBusinesses: () => Promise<BusinessRow[]>;
+  selectQuoteCandidates: (businessId: number, limit: number) => Promise<CandidateRow[]>;
+  generateCaptionVariants: (params: { businessName: string; quoteText: string }) => Promise<CaptionSet>;
+  updateDraftCaption: (draftPostId: number, captionText: string) => Promise<void>;
+  renderDraftImage: (params: {
+    draftPostId: number;
+    businessName: string;
+    quoteText: string;
+    brandHex?: string | null;
+    logoUrl?: string | null;
+  }) => Promise<{ publicPath: string }>;
+  updateDraftImagePath: (draftPostId: number, imagePath: string) => Promise<void>;
+  markDraftFailed: (draftPostId: number, reason: string) => Promise<void>;
+};
+
+function pickCaption(captions: CaptionSet) {
+  return captions.friendly || captions.premium || captions.playful;
+}
+
+export function createDraftGenerationRunner(deps: DraftPipelineDeps) {
+  return async function runDraftGenerationJob(options: PipelineOptions = {}): Promise<PipelineResult> {
+    const perBusinessLimit = options.perBusinessLimit ?? 5;
+    const businesses = await deps.listBusinesses();
+
+    let candidatesInserted = 0;
+    let draftsCompleted = 0;
+    let draftsFailed = 0;
+
+    for (const business of businesses) {
+      const candidates = await deps.selectQuoteCandidates(business.id, perBusinessLimit);
+      candidatesInserted += candidates.length;
+
+      for (const candidate of candidates) {
+        try {
+          const captions = await deps.generateCaptionVariants({
+            businessName: business.name,
+            quoteText: candidate.quoteText
+          });
+
+          await deps.updateDraftCaption(candidate.draftPostId, pickCaption(captions));
+
+          const brandHex = business.brand_colors?.primary ?? null;
+          const rendered = await deps.renderDraftImage({
+            draftPostId: candidate.draftPostId,
+            businessName: business.name,
+            quoteText: candidate.quoteText,
+            brandHex,
+            logoUrl: business.logo_url
+          });
+
+          await deps.updateDraftImagePath(candidate.draftPostId, rendered.publicPath);
+          draftsCompleted += 1;
+        } catch (err) {
+          draftsFailed += 1;
+          const message = err instanceof Error ? err.message : String(err);
+          await deps.markDraftFailed(candidate.draftPostId, `pipeline_failed: ${message}`);
+        }
+      }
+    }
+
+    return {
+      businessesScanned: businesses.length,
+      candidatesInserted,
+      draftsCompleted,
+      draftsFailed
+    };
+  };
+}
+
+const runDraftGenerationWithDb = createDraftGenerationRunner({
+  listBusinesses: async () => {
+    const businesses = await query<BusinessRow>(
+      `SELECT id, name, brand_colors, logo_url
+       FROM businesses
+       ORDER BY id ASC`
+    );
+    return businesses.rows;
+  },
+  selectQuoteCandidates,
+  generateCaptionVariants,
+  updateDraftCaption: async (draftPostId, captionText) => {
+    await query(
+      `UPDATE draft_posts
+       SET caption_text = $2,
+           updated_at = NOW()
+       WHERE id = $1`,
+      [draftPostId, captionText]
+    );
+  },
+  renderDraftImage,
+  updateDraftImagePath: async (draftPostId, imagePath) => {
+    await query(
+      `UPDATE draft_posts
+       SET image_path = $2,
+           updated_at = NOW()
+       WHERE id = $1`,
+      [draftPostId, imagePath]
+    );
+  },
+  markDraftFailed: async (draftPostId, reason) => {
+    await query(
+      `UPDATE draft_posts
+       SET status = 'failed',
+           audit_note = LEFT($2, 300),
+           updated_at = NOW()
+       WHERE id = $1`,
+      [draftPostId, reason]
+    );
+  }
+});
+
+export async function runDraftGenerationJob(options: PipelineOptions = {}) {
+  return runDraftGenerationWithDb(options);
+}
+
+export const __internal = { pickCaption };

--- a/lib/services/quoteSelector.ts
+++ b/lib/services/quoteSelector.ts
@@ -35,10 +35,15 @@ function scoreReview(r: ReviewRow): number {
 
 export async function selectQuoteCandidates(businessId: number, limit = 5) {
   const reviews = await query<ReviewRow>(
-    `SELECT id, business_id, rating, text
-     FROM reviews
-     WHERE business_id = $1
-     ORDER BY reviewed_at DESC, id DESC
+    `SELECT r.id, r.business_id, r.rating, r.text
+     FROM reviews r
+     WHERE r.business_id = $1
+       AND NOT EXISTS (
+         SELECT 1
+         FROM draft_posts d
+         WHERE d.review_id = r.id
+       )
+     ORDER BY r.reviewed_at DESC, r.id DESC
      LIMIT 300`,
     [businessId]
   );

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start -H 0.0.0.0 -p 3000",
     "lint": "echo 'lint placeholder'",
     "typecheck": "tsc --noEmit",
-    "test": "echo 'test placeholder'",
+    "test": "npx ts-node --compiler-options '{\"module\":\"CommonJS\",\"moduleResolution\":\"node\"}' scripts/test-draft-pipeline.ts",
     "db:migrate": "npx ts-node --compiler-options '{\"module\":\"CommonJS\",\"moduleResolution\":\"node\"}' scripts/migrate.ts",
     "db:health": "npx ts-node --compiler-options '{\"module\":\"CommonJS\",\"moduleResolution\":\"node\"}' scripts/db-health.ts",
     "worker:schedule": "npx ts-node --compiler-options '{\"module\":\"CommonJS\",\"moduleResolution\":\"node\"}' scripts/schedule-worker.ts"

--- a/scripts/test-draft-pipeline.ts
+++ b/scripts/test-draft-pipeline.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { createDraftGenerationRunner } from "../lib/services/draftPipeline";
+
+async function successPathTest() {
+  const updatedCaptions: Array<{ id: number; caption: string }> = [];
+  const updatedImages: Array<{ id: number; imagePath: string }> = [];
+
+  const run = createDraftGenerationRunner({
+    listBusinesses: async () => [
+      { id: 7, name: "Cafe Nova", brand_colors: { primary: "#112233" }, logo_url: null }
+    ],
+    selectQuoteCandidates: async () => [
+      { draftPostId: 101, reviewId: 501, quoteText: "Amazing coffee and staff", score: 100 }
+    ],
+    generateCaptionVariants: async () => ({
+      friendly: "Cafe Nova made our day ☕",
+      premium: "",
+      playful: ""
+    }),
+    updateDraftCaption: async (id, caption) => {
+      updatedCaptions.push({ id, caption });
+    },
+    renderDraftImage: async () => ({ publicPath: "/generated/draft-101.png" }),
+    updateDraftImagePath: async (id, imagePath) => {
+      updatedImages.push({ id, imagePath });
+    },
+    markDraftFailed: async () => {
+      throw new Error("should not mark failed in success path");
+    }
+  });
+
+  const result = await run();
+
+  assert.deepEqual(result, {
+    businessesScanned: 1,
+    candidatesInserted: 1,
+    draftsCompleted: 1,
+    draftsFailed: 0
+  });
+  assert.deepEqual(updatedCaptions, [{ id: 101, caption: "Cafe Nova made our day ☕" }]);
+  assert.deepEqual(updatedImages, [{ id: 101, imagePath: "/generated/draft-101.png" }]);
+}
+
+async function failurePathTest() {
+  const failures: Array<{ id: number; reason: string }> = [];
+
+  const run = createDraftGenerationRunner({
+    listBusinesses: async () => [
+      { id: 8, name: "North Pizza", brand_colors: null, logo_url: null }
+    ],
+    selectQuoteCandidates: async () => [
+      { draftPostId: 202, reviewId: 601, quoteText: "Great service", score: 88 }
+    ],
+    generateCaptionVariants: async () => {
+      throw new Error("upstream timeout");
+    },
+    updateDraftCaption: async () => {
+      throw new Error("should not update caption in failure path");
+    },
+    renderDraftImage: async () => {
+      throw new Error("should not render in failure path");
+    },
+    updateDraftImagePath: async () => {
+      throw new Error("should not update image in failure path");
+    },
+    markDraftFailed: async (id, reason) => {
+      failures.push({ id, reason });
+    }
+  });
+
+  const result = await run();
+
+  assert.deepEqual(result, {
+    businessesScanned: 1,
+    candidatesInserted: 1,
+    draftsCompleted: 0,
+    draftsFailed: 1
+  });
+  assert.equal(failures.length, 1);
+  assert.equal(failures[0].id, 202);
+  assert.match(failures[0].reason, /pipeline_failed: upstream timeout/);
+}
+
+async function main() {
+  await successPathTest();
+  await failurePathTest();
+  console.log("draft pipeline tests passed");
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.stack : String(err));
+  process.exitCode = 1;
+});

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,9 +1,49 @@
-function main() {
-  const timestamp = new Date().toISOString();
-  console.log(`[${timestamp}] worker up`);
-  setInterval(() => {
-    const now = new Date().toISOString();
-    console.log(`[${now}] worker heartbeat`);
-  }, 30000);
+import { pool } from "../lib/db";
+import { runDraftGenerationJob } from "../lib/services/draftPipeline";
+
+const TICK_MS = Number(process.env.DRAFT_PIPELINE_INTERVAL_MS ?? 60_000);
+let running = false;
+let stopped = false;
+
+async function runTick() {
+  if (running || stopped) return;
+  running = true;
+
+  try {
+    const result = await runDraftGenerationJob({ perBusinessLimit: 5 });
+    console.log(
+      JSON.stringify({
+        event: "draft_pipeline.run_complete",
+        ...result
+      })
+    );
+  } catch (err) {
+    console.error("draft_pipeline_failed", err instanceof Error ? err.message : String(err));
+  } finally {
+    running = false;
+  }
 }
+
+async function shutdown(signal: string) {
+  if (stopped) return;
+  stopped = true;
+  console.log(`[${new Date().toISOString()}] shutting down worker (${signal})`);
+
+  while (running) {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  await pool.end();
+  process.exit(0);
+}
+
+function main() {
+  console.log(`[${new Date().toISOString()}] worker up`);
+  runTick();
+  setInterval(runTick, TICK_MS);
+
+  process.on("SIGINT", () => void shutdown("SIGINT"));
+  process.on("SIGTERM", () => void shutdown("SIGTERM"));
+}
+
 main();


### PR DESCRIPTION
Closes #24

## Summary
- add a real draft-generation worker pipeline (`worker/index.ts`) that runs on an interval and executes quote selection -> caption generation -> image rendering
- add `lib/services/draftPipeline.ts` to orchestrate draft creation, caption/image updates, and failed-draft marking
- prevent duplicate candidate creation by skipping reviews already linked to a draft in `quoteSelector`
- document the worker behavior in README
- replace placeholder test script with a targeted pipeline test harness (`scripts/test-draft-pipeline.ts`)

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`
- `npm run build`

All commands pass locally.
