### PR TITLE
chore: add GitHub webhook trigger for OpenClaw PR review automation

### DIFF
--- a/.github/workflows/openclaw-pr-webhook.yml
+++ b/.github/workflows/openclaw-pr-webhook.yml
@@ -1,0 +1,56 @@
+name: OpenClaw PR Review Trigger
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  trigger-openclaw:
+    runs-on: ubuntu-latest
+    if: ${{ secrets.OPENCLAW_HOOK_AGENT_URL != '' && secrets.OPENCLAW_HOOK_TOKEN != '' }}
+    steps:
+      - name: Send event to OpenClaw hook
+        env:
+          HOOK_URL: ${{ secrets.OPENCLAW_HOOK_AGENT_URL }}
+          HOOK_TOKEN: ${{ secrets.OPENCLAW_HOOK_TOKEN }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          ACTION: ${{ github.event.action }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.review.pull_request_url || '' }}
+          PR_TITLE: ${{ github.event.pull_request.title || '' }}
+          PR_URL: ${{ github.event.pull_request.html_url || github.event.review.html_url || '' }}
+          SENDER: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+
+          MESSAGE=$(cat <<MSG
+GitHub webhook event received.
+
+Repo: ${REPO}
+Event: ${EVENT_NAME}
+Action: ${ACTION}
+PR: ${PR_NUMBER}
+Title: ${PR_TITLE}
+URL: ${PR_URL}
+Sender: ${SENDER}
+
+Please run a review automation pass now:
+/gh-issues ${REPO} --reviews-only --yes --cron
+MSG
+)
+
+          jq -n --arg message "$MESSAGE" '{
+            name: "GitHub",
+            wakeMode: "now",
+            deliver: false,
+            message: $message
+          }' > payload.json
+
+          curl -sS -X POST "$HOOK_URL" \
+            -H "Authorization: Bearer $HOOK_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data @payload.json

--- a/.github/workflows/openclaw-pr-webhook.yml
+++ b/.github/workflows/openclaw-pr-webhook.yml
@@ -20,12 +20,13 @@ jobs:
           REPO: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
           ACTION: ${{ github.event.action }}
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.review.pull_request_url || '' }}
-          PR_TITLE: ${{ github.event.pull_request.title || '' }}
-          PR_URL: ${{ github.event.pull_request.html_url || github.event.review.html_url || '' }}
           SENDER: ${{ github.actor }}
         run: |
           set -euo pipefail
+
+          PR_NUMBER=$(jq -r '.pull_request.number // .review.pull_request_url // ""' "$GITHUB_EVENT_PATH")
+          PR_TITLE=$(jq -r '.pull_request.title // ""' "$GITHUB_EVENT_PATH")
+          PR_URL=$(jq -r '.pull_request.html_url // .review.html_url // ""' "$GITHUB_EVENT_PATH")
 
           MESSAGE=$(cat <<MSG
 GitHub webhook event received.


### PR DESCRIPTION
## What changed
- Added GitHub Actions workflow: `.github/workflows/openclaw-pr-webhook.yml`
- Triggers on PR open/update + review + inline review comment events
- Sends an event payload to OpenClaw `/hooks/agent` when secrets are configured

## Required repo secrets
- `OPENCLAW_HOOK_AGENT_URL` (example: `https://<your-host>/hooks/agent`)
- `OPENCLAW_HOOK_TOKEN` (same token as OpenClaw `hooks.token`)

## Behavior
- Sends an event summary and asks OpenClaw to run:
  - `/gh-issues <repo> --reviews-only --yes --cron`
- Uses `deliver: false` to avoid noisy webhook replies

## Why
Provides near real-time review handling from GitHub events while cron remains fallback for reliability.