### PR TITLE
feat: business branding settings (logo, colors, tone)

### DIFF
--- a/app/api/businesses/[id]/route.ts
+++ b/app/api/businesses/[id]/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server";
+import { query } from "../../../../lib/db";
+
+type BrandTone = "friendly" | "premium" | "playful";
+
+function normalizeHex(input: unknown): string | null {
+  const value = String(input ?? "").trim();
+  if (!value) return null;
+  if (!/^#?[0-9a-fA-F]{6}$/.test(value)) return null;
+  return value.startsWith("#") ? value.toLowerCase() : `#${value.toLowerCase()}`;
+}
+
+function normalizeBrandTone(input: unknown): BrandTone {
+  const tone = String(input ?? "friendly").trim().toLowerCase();
+  if (tone === "premium" || tone === "playful") return tone;
+  return "friendly";
+}
+
+export async function PATCH(
+  req: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  const { id } = await context.params;
+  const businessId = Number(id);
+
+  if (!Number.isInteger(businessId) || businessId <= 0) {
+    return NextResponse.json({ error: "valid business id is required" }, { status: 400 });
+  }
+
+  const body = await req.json();
+  const logoUrl = String(body?.logoUrl ?? "").trim() || null;
+  const primaryColor = normalizeHex(body?.primaryColor);
+  const secondaryColor = normalizeHex(body?.secondaryColor);
+  const brandTone = normalizeBrandTone(body?.brandTone);
+
+  if (!primaryColor || !secondaryColor) {
+    return NextResponse.json(
+      { error: "primaryColor and secondaryColor must be valid 6-digit hex colors" },
+      { status: 400 }
+    );
+  }
+
+  const result = await query<{
+    id: number;
+    name: string;
+    logo_url: string | null;
+    brand_tone: BrandTone;
+    brand_colors: { primary?: string; secondary?: string };
+  }>(
+    `UPDATE businesses
+     SET logo_url = $2,
+         brand_colors = $3::jsonb,
+         brand_tone = $4
+     WHERE id = $1
+     RETURNING id, name, logo_url, brand_tone, brand_colors`,
+    [
+      businessId,
+      logoUrl,
+      JSON.stringify({ primary: primaryColor, secondary: secondaryColor }),
+      brandTone
+    ]
+  );
+
+  if (!result.rowCount) {
+    return NextResponse.json({ error: "business not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ business: result.rows[0] });
+}

--- a/app/api/businesses/route.ts
+++ b/app/api/businesses/route.ts
@@ -1,27 +1,76 @@
 import { NextRequest, NextResponse } from "next/server";
 import { query } from "../../../lib/db";
 
+type BrandTone = "friendly" | "premium" | "playful";
+
+function normalizeHex(input: unknown): string | null {
+  const value = String(input ?? "").trim();
+  if (!value) return null;
+  if (!/^#?[0-9a-fA-F]{6}$/.test(value)) return null;
+  return value.startsWith("#") ? value.toLowerCase() : `#${value.toLowerCase()}`;
+}
+
+function normalizeBrandTone(input: unknown): BrandTone {
+  const tone = String(input ?? "friendly").trim().toLowerCase();
+  if (tone === "premium" || tone === "playful") return tone;
+  return "friendly";
+}
+
 export async function GET() {
-  const result = await query<{ id: number; name: string }>(
-    "SELECT id, name FROM businesses ORDER BY id ASC"
+  const result = await query<{
+    id: number;
+    name: string;
+    logo_url: string | null;
+    brand_tone: BrandTone;
+    brand_colors: { primary?: string; secondary?: string } | null;
+  }>(
+    "SELECT id, name, logo_url, brand_tone, brand_colors FROM businesses ORDER BY id ASC"
   );
-  return NextResponse.json({ businesses: result.rows });
+
+  const businesses = result.rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    logo_url: row.logo_url,
+    brand_tone: row.brand_tone,
+    brand_colors: {
+      primary: row.brand_colors?.primary ?? "#1f2937",
+      secondary: row.brand_colors?.secondary ?? "#374151"
+    }
+  }));
+
+  return NextResponse.json({ businesses });
 }
 
 export async function POST(req: NextRequest) {
   const body = await req.json();
   const name = String(body?.name ?? "").trim();
   const timezone = String(body?.timezone ?? "America/Toronto").trim();
+  const logoUrl = String(body?.logoUrl ?? "").trim() || null;
+  const primaryColor = normalizeHex(body?.primaryColor) ?? "#1f2937";
+  const secondaryColor = normalizeHex(body?.secondaryColor) ?? "#374151";
+  const brandTone = normalizeBrandTone(body?.brandTone);
 
   if (!name) {
     return NextResponse.json({ error: "name is required" }, { status: 400 });
   }
 
-  const result = await query<{ id: number; name: string }>(
-    `INSERT INTO businesses (name, timezone, brand_colors)
-     VALUES ($1, $2, '{}'::jsonb)
-     RETURNING id, name`,
-    [name, timezone]
+  const result = await query<{
+    id: number;
+    name: string;
+    logo_url: string | null;
+    brand_tone: BrandTone;
+    brand_colors: { primary?: string; secondary?: string };
+  }>(
+    `INSERT INTO businesses (name, timezone, brand_colors, logo_url, brand_tone)
+     VALUES ($1, $2, $3::jsonb, $4, $5)
+     RETURNING id, name, logo_url, brand_tone, brand_colors`,
+    [
+      name,
+      timezone,
+      JSON.stringify({ primary: primaryColor, secondary: secondaryColor }),
+      logoUrl,
+      brandTone
+    ]
   );
 
   return NextResponse.json({ business: result.rows[0] }, { status: 201 });

--- a/app/api/captions/generate/route.ts
+++ b/app/api/captions/generate/route.ts
@@ -15,8 +15,9 @@ export async function POST(req: NextRequest) {
       id: number;
       quote_text: string;
       business_name: string;
+      brand_tone: "friendly" | "premium" | "playful";
     }>(
-      `SELECT d.id, d.quote_text, b.name AS business_name
+      `SELECT d.id, d.quote_text, b.name AS business_name, b.brand_tone
        FROM draft_posts d
        JOIN businesses b ON b.id = d.business_id
        WHERE d.id = $1
@@ -31,7 +32,8 @@ export async function POST(req: NextRequest) {
     const row = draftRes.rows[0];
     const captions = await generateCaptionVariants({
       businessName: row.business_name,
-      quoteText: row.quote_text
+      quoteText: row.quote_text,
+      brandTone: row.brand_tone
     });
 
     return NextResponse.json({ captions });

--- a/app/api/images/render/route.ts
+++ b/app/api/images/render/route.ts
@@ -17,8 +17,9 @@ export async function POST(req: NextRequest) {
       business_name: string;
       brand_colors: Record<string, string> | null;
       logo_url: string | null;
+      brand_tone: "friendly" | "premium" | "playful";
     }>(
-      `SELECT d.id, d.quote_text, b.name AS business_name, b.brand_colors, b.logo_url
+      `SELECT d.id, d.quote_text, b.name AS business_name, b.brand_colors, b.logo_url, b.brand_tone
        FROM draft_posts d
        JOIN businesses b ON b.id = d.business_id
        WHERE d.id = $1
@@ -32,13 +33,16 @@ export async function POST(req: NextRequest) {
 
     const row = draft.rows[0];
     const brandHex = row.brand_colors?.primary ?? null;
+    const secondaryBrandHex = row.brand_colors?.secondary ?? null;
 
     const rendered = await renderDraftImage({
       draftPostId,
       businessName: row.business_name,
       quoteText: row.quote_text,
       brandHex,
-      logoUrl: row.logo_url
+      secondaryBrandHex,
+      logoUrl: row.logo_url,
+      brandTone: row.brand_tone
     });
 
     const updated = await query<{ id: number; image_path: string }>(

--- a/app/import/page.tsx
+++ b/app/import/page.tsx
@@ -1,8 +1,20 @@
 "use client";
 
-import { FormEvent, useEffect, useState } from "react";
+import { FormEvent, useEffect, useMemo, useState } from "react";
 
-type Business = { id: number; name: string };
+type BrandTone = "friendly" | "premium" | "playful";
+
+type Business = {
+  id: number;
+  name: string;
+  logo_url?: string | null;
+  brand_tone?: BrandTone;
+  brand_colors?: {
+    primary?: string;
+    secondary?: string;
+  };
+};
+
 type Review = {
   id: number;
   rating: number;
@@ -11,12 +23,32 @@ type Review = {
   reviewed_at: string;
 };
 
+const DEFAULT_PRIMARY = "#1f2937";
+const DEFAULT_SECONDARY = "#374151";
+
+function normalizeHex(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  if (!/^#?[0-9a-fA-F]{6}$/.test(trimmed)) return "";
+  return trimmed.startsWith("#") ? trimmed.toLowerCase() : `#${trimmed.toLowerCase()}`;
+}
+
 export default function ImportPage() {
   const [businesses, setBusinesses] = useState<Business[]>([]);
   const [selectedBusinessId, setSelectedBusinessId] = useState<string>("");
   const [newBusinessName, setNewBusinessName] = useState("");
   const [result, setResult] = useState<string>("");
   const [reviews, setReviews] = useState<Review[]>([]);
+
+  const [logoUrl, setLogoUrl] = useState("");
+  const [primaryColor, setPrimaryColor] = useState(DEFAULT_PRIMARY);
+  const [secondaryColor, setSecondaryColor] = useState(DEFAULT_SECONDARY);
+  const [brandTone, setBrandTone] = useState<BrandTone>("friendly");
+
+  const selectedBusiness = useMemo(
+    () => businesses.find((b) => String(b.id) === selectedBusinessId) ?? null,
+    [businesses, selectedBusinessId]
+  );
 
   async function loadBusinesses() {
     const res = await fetch("/api/businesses");
@@ -42,6 +74,21 @@ export default function ImportPage() {
     loadReviews(selectedBusinessId);
   }, [selectedBusinessId]);
 
+  useEffect(() => {
+    if (!selectedBusiness) {
+      setLogoUrl("");
+      setPrimaryColor(DEFAULT_PRIMARY);
+      setSecondaryColor(DEFAULT_SECONDARY);
+      setBrandTone("friendly");
+      return;
+    }
+
+    setLogoUrl(selectedBusiness.logo_url ?? "");
+    setPrimaryColor(selectedBusiness.brand_colors?.primary ?? DEFAULT_PRIMARY);
+    setSecondaryColor(selectedBusiness.brand_colors?.secondary ?? DEFAULT_SECONDARY);
+    setBrandTone(selectedBusiness.brand_tone ?? "friendly");
+  }, [selectedBusiness]);
+
   async function createBusiness(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     const name = newBusinessName.trim();
@@ -50,7 +97,14 @@ export default function ImportPage() {
     const res = await fetch("/api/businesses", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ name, timezone: "America/Toronto" })
+      body: JSON.stringify({
+        name,
+        timezone: "America/Toronto",
+        logoUrl,
+        primaryColor: normalizeHex(primaryColor) || DEFAULT_PRIMARY,
+        secondaryColor: normalizeHex(secondaryColor) || DEFAULT_SECONDARY,
+        brandTone
+      })
     });
     const data = await res.json();
     if (!res.ok) {
@@ -62,6 +116,38 @@ export default function ImportPage() {
     await loadBusinesses();
     setSelectedBusinessId(String(data.business.id));
     setResult(`Created business: ${data.business.name}`);
+  }
+
+  async function saveBranding(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!selectedBusinessId) return;
+
+    const normalizedPrimary = normalizeHex(primaryColor);
+    const normalizedSecondary = normalizeHex(secondaryColor);
+    if (!normalizedPrimary || !normalizedSecondary) {
+      setResult("Branding save failed: colors must be valid hex (e.g. #1f2937)");
+      return;
+    }
+
+    const res = await fetch(`/api/businesses/${selectedBusinessId}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        logoUrl: logoUrl.trim(),
+        primaryColor: normalizedPrimary,
+        secondaryColor: normalizedSecondary,
+        brandTone
+      })
+    });
+
+    const data = await res.json();
+    if (!res.ok) {
+      setResult(`Branding save failed: ${data.error ?? "unknown error"}`);
+      return;
+    }
+
+    setResult(`Saved branding for ${data.business.name}`);
+    await loadBusinesses();
   }
 
   async function importCsv(e: FormEvent<HTMLFormElement>) {
@@ -119,6 +205,61 @@ export default function ImportPage() {
       </section>
 
       <section style={{ marginBottom: 20 }}>
+        <h2>Branding settings</h2>
+        <p>Logo + colors + tone are used for captions and rendered image templates.</p>
+        <form onSubmit={saveBranding}>
+          <div style={{ display: "grid", gap: 8, maxWidth: 520 }}>
+            <label>
+              Logo URL
+              <input
+                value={logoUrl}
+                onChange={(e) => setLogoUrl(e.target.value)}
+                placeholder="https://example.com/logo.png"
+                style={{ display: "block", width: "100%" }}
+              />
+            </label>
+
+            <label>
+              Primary color
+              <input
+                value={primaryColor}
+                onChange={(e) => setPrimaryColor(e.target.value)}
+                placeholder="#1f2937"
+                style={{ display: "block", width: "100%" }}
+              />
+            </label>
+
+            <label>
+              Secondary color
+              <input
+                value={secondaryColor}
+                onChange={(e) => setSecondaryColor(e.target.value)}
+                placeholder="#374151"
+                style={{ display: "block", width: "100%" }}
+              />
+            </label>
+
+            <label>
+              Brand tone
+              <select
+                value={brandTone}
+                onChange={(e) => setBrandTone(e.target.value as BrandTone)}
+                style={{ display: "block", width: "100%" }}
+              >
+                <option value="friendly">friendly</option>
+                <option value="premium">premium</option>
+                <option value="playful">playful</option>
+              </select>
+            </label>
+          </div>
+
+          <button type="submit" disabled={!selectedBusinessId} style={{ marginTop: 10 }}>
+            Save branding
+          </button>
+        </form>
+      </section>
+
+      <section style={{ marginBottom: 20 }}>
         <h2>Upload CSV</h2>
         <p>Required columns: rating, text, reviewed_at (ISO). Optional: author_name.</p>
         <form onSubmit={importCsv}>
@@ -129,7 +270,11 @@ export default function ImportPage() {
         </form>
       </section>
 
-      {result ? <p><strong>{result}</strong></p> : null}
+      {result ? (
+        <p>
+          <strong>{result}</strong>
+        </p>
+      ) : null}
 
       <section>
         <h2>Imported reviews (latest 100)</h2>

--- a/db/migrations/002_business_brand_tone.sql
+++ b/db/migrations/002_business_brand_tone.sql
@@ -1,0 +1,16 @@
+ALTER TABLE businesses
+ADD COLUMN IF NOT EXISTS brand_tone TEXT NOT NULL DEFAULT 'friendly';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'businesses_brand_tone_check'
+  ) THEN
+    ALTER TABLE businesses
+    ADD CONSTRAINT businesses_brand_tone_check
+    CHECK (brand_tone IN ('friendly', 'premium', 'playful'));
+  END IF;
+END
+$$;

--- a/lib/services/captions.ts
+++ b/lib/services/captions.ts
@@ -28,22 +28,27 @@ function sanitizeCaption(text: string): string {
 export async function generateCaptionVariants(params: {
   businessName: string;
   quoteText: string;
+  brandTone?: "friendly" | "premium" | "playful";
 }): Promise<CaptionStyles> {
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) {
     throw new Error("OPENAI_API_KEY is not set");
   }
 
+  const preferredTone = params.brandTone ?? "friendly";
+
   const prompt = `You are writing social captions for a local business.
 Business: ${params.businessName}
 Quote: "${params.quoteText}"
+Preferred brand tone: ${preferredTone}
 
 Return ONLY JSON with keys friendly, premium, playful.
 Rules:
 - include business name subtly (not spammy)
 - each caption <= 200 chars
 - max 5 hashtags per caption
-- no markdown, no extra keys`;
+- no markdown, no extra keys
+- make the ${preferredTone} caption the strongest/highest-quality option`;
 
   const res = await fetch("https://api.openai.com/v1/responses", {
     method: "POST",

--- a/lib/services/imageRenderer.ts
+++ b/lib/services/imageRenderer.ts
@@ -16,27 +16,47 @@ export async function renderDraftImage(params: {
   businessName: string;
   quoteText: string;
   brandHex?: string | null;
+  secondaryBrandHex?: string | null;
   logoUrl?: string | null;
+  brandTone?: "friendly" | "premium" | "playful";
 }) {
   const width = 1080;
   const height = 1080;
-  const bg = params.brandHex && /^#?[0-9a-fA-F]{6}$/.test(params.brandHex)
-    ? (params.brandHex.startsWith("#") ? params.brandHex : `#${params.brandHex}`)
-    : "#1f2937";
+
+  const normalizeHex = (input: string | null | undefined, fallback: string) => {
+    if (!input) return fallback;
+    if (!/^#?[0-9a-fA-F]{6}$/.test(input)) return fallback;
+    return input.startsWith("#") ? input : `#${input}`;
+  };
+
+  const primary = normalizeHex(params.brandHex, "#1f2937");
+  const secondary = normalizeHex(params.secondaryBrandHex, "#374151");
+
+  const tone = params.brandTone ?? "friendly";
+  const toneFont = tone === "premium" ? "Georgia,serif" : "Arial,sans-serif";
+  const quoteColor = tone === "playful" ? "#fef08a" : "#ffffff";
 
   const business = esc(params.businessName);
   const quote = esc(params.quoteText);
   const logoBlock = params.logoUrl
-    ? `<text x="80" y="180" fill="#ffffff" font-size="28" font-family="Arial">logo: ${esc(params.logoUrl)}</text>`
+    ? `<text x="80" y="190" fill="#ffffff" font-size="22" font-family="Arial">logo: ${esc(params.logoUrl)}</text>`
     : "";
 
   const svg = `
   <svg width="${width}" height="${height}" xmlns="http://www.w3.org/2000/svg">
-    <rect width="100%" height="100%" fill="${bg}" />
-    <text x="80" y="100" fill="#ffffff" font-size="46" font-weight="700" font-family="Arial">${business}</text>
+    <defs>
+      <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0%" stop-color="${primary}" />
+        <stop offset="100%" stop-color="${secondary}" />
+      </linearGradient>
+    </defs>
+    <rect width="100%" height="100%" fill="url(#bg)" />
+    <rect x="0" y="0" width="100%" height="14" fill="${secondary}" />
+    <text x="80" y="110" fill="#ffffff" font-size="46" font-weight="700" font-family="Arial">${business}</text>
+    <text x="900" y="110" fill="#ffffff" font-size="20" text-anchor="end" font-family="Arial">tone: ${tone}</text>
     ${logoBlock}
-    <foreignObject x="80" y="250" width="920" height="680">
-      <div xmlns="http://www.w3.org/1999/xhtml" style="font-family:Arial,sans-serif;color:#ffffff;font-size:48px;line-height:1.25;">
+    <foreignObject x="80" y="260" width="920" height="680">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="font-family:${toneFont};color:${quoteColor};font-size:48px;line-height:1.25;">
         “${quote}”
       </div>
     </foreignObject>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start -H 0.0.0.0 -p 3000",
     "lint": "echo 'lint placeholder'",
     "typecheck": "tsc --noEmit",
-    "test": "npx ts-node --compiler-options '{\"module\":\"CommonJS\",\"moduleResolution\":\"node\"}' scripts/test-draft-pipeline.ts",
+    "test": "npx ts-node --compiler-options '{\"module\":\"CommonJS\",\"moduleResolution\":\"node\"}' scripts/test-draft-pipeline.ts && npx ts-node --compiler-options '{\"module\":\"CommonJS\",\"moduleResolution\":\"node\"}' scripts/test-business-branding-routes.ts",
     "db:migrate": "npx ts-node --compiler-options '{\"module\":\"CommonJS\",\"moduleResolution\":\"node\"}' scripts/migrate.ts",
     "db:health": "npx ts-node --compiler-options '{\"module\":\"CommonJS\",\"moduleResolution\":\"node\"}' scripts/db-health.ts",
     "worker:schedule": "npx ts-node --compiler-options '{\"module\":\"CommonJS\",\"moduleResolution\":\"node\"}' scripts/schedule-worker.ts"

--- a/scripts/test-business-branding-routes.ts
+++ b/scripts/test-business-branding-routes.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+
+const dbModule = require("../lib/db");
+const captionsModule = require("../lib/services/captions");
+const imageRendererModule = require("../lib/services/imageRenderer");
+
+function makeJsonRequest(body: unknown) {
+  return {
+    json: async () => body
+  } as any;
+}
+
+async function postNormalizesToneAndColorsTest() {
+  let capturedParams: unknown[] = [];
+
+  dbModule.query = async (_sql: string, params: unknown[]) => {
+    capturedParams = params;
+    return {
+      rows: [
+        {
+          id: 1,
+          name: "Tone Test",
+          logo_url: null,
+          brand_tone: params[4],
+          brand_colors: JSON.parse(String(params[2]))
+        }
+      ],
+      rowCount: 1
+    };
+  };
+
+  const businessesRoute = require("../app/api/businesses/route");
+  const res = await businessesRoute.POST(
+    makeJsonRequest({
+      name: "Tone Test",
+      primaryColor: "NOT-HEX",
+      secondaryColor: " 123456 ",
+      brandTone: "LOUD"
+    })
+  );
+
+  assert.equal(res.status, 201);
+  assert.equal(capturedParams[4], "friendly", "invalid tone should fall back to friendly");
+  assert.deepEqual(JSON.parse(String(capturedParams[2])), {
+    primary: "#1f2937",
+    secondary: "#123456"
+  });
+}
+
+async function patchRejectsInvalidHexTest() {
+  let queryCalled = false;
+
+  dbModule.query = async () => {
+    queryCalled = true;
+    return { rows: [], rowCount: 0 };
+  };
+
+  const businessByIdRoute = require("../app/api/businesses/[id]/route");
+  const res = await businessByIdRoute.PATCH(
+    makeJsonRequest({
+      primaryColor: "#12345",
+      secondaryColor: "#111111",
+      brandTone: "premium"
+    }),
+    { params: Promise.resolve({ id: "77" }) }
+  );
+
+  assert.equal(res.status, 400);
+  assert.equal(queryCalled, false, "invalid hex should be rejected before DB query");
+}
+
+async function patchMissingBusinessAndToneFallbackTest() {
+  let capturedParams: unknown[] = [];
+
+  dbModule.query = async (_sql: string, params: unknown[]) => {
+    capturedParams = params;
+    return { rows: [], rowCount: 0 };
+  };
+
+  const businessByIdRoute = require("../app/api/businesses/[id]/route");
+  const res = await businessByIdRoute.PATCH(
+    makeJsonRequest({
+      primaryColor: "#111111",
+      secondaryColor: "222222",
+      brandTone: "serious"
+    }),
+    { params: Promise.resolve({ id: "999" }) }
+  );
+
+  assert.equal(res.status, 404);
+  assert.equal(capturedParams[3], "friendly", "invalid patch tone should fall back to friendly");
+}
+
+async function captionsRoutePropagatesToneTest() {
+  let capturedTone: string | null = null;
+
+  dbModule.query = async () => ({
+    rows: [{ id: 44, quote_text: "Amazing!", business_name: "Cafe", brand_tone: "playful" }],
+    rowCount: 1
+  });
+
+  captionsModule.generateCaptionVariants = async (input: any) => {
+    capturedTone = input.brandTone;
+    return { friendly: "a", premium: "b", playful: "c" };
+  };
+
+  const captionsRoute = require("../app/api/captions/generate/route");
+  const res = await captionsRoute.POST(makeJsonRequest({ draftPostId: 44 }));
+
+  assert.equal(res.status, 200);
+  assert.equal(capturedTone, "playful");
+}
+
+async function imageRenderRoutePropagatesToneTest() {
+  let capturedTone: string | null = null;
+
+  dbModule.query = async (sql: string) => {
+    if (sql.includes("SELECT d.id")) {
+      return {
+        rows: [
+          {
+            id: 55,
+            quote_text: "Great",
+            business_name: "Deli",
+            brand_colors: { primary: "#111111", secondary: "#222222" },
+            logo_url: null,
+            brand_tone: "premium"
+          }
+        ],
+        rowCount: 1
+      };
+    }
+    return { rows: [{ id: 55, image_path: "/generated/55.png" }], rowCount: 1 };
+  };
+
+  imageRendererModule.renderDraftImage = async (input: any) => {
+    capturedTone = input.brandTone;
+    return { publicPath: "/generated/55.png" };
+  };
+
+  const imagesRoute = require("../app/api/images/render/route");
+  const res = await imagesRoute.POST(makeJsonRequest({ draftPostId: 55 }));
+
+  assert.equal(res.status, 200);
+  assert.equal(capturedTone, "premium");
+}
+
+async function main() {
+  await postNormalizesToneAndColorsTest();
+  await patchRejectsInvalidHexTest();
+  await patchMissingBusinessAndToneFallbackTest();
+  await captionsRoutePropagatesToneTest();
+  await imageRenderRoutePropagatesToneTest();
+  console.log("business branding route tests passed");
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.stack : String(err));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Closes #25

## Summary
- added per-business branding fields (logo URL, primary color, secondary color, brand tone) to the businesses API and a new `PATCH /api/businesses/:id` endpoint
- added a DB migration to persist `brand_tone` with allowed values: friendly, premium, playful
- added branding controls to the import page so operators can configure and save branding per business
- wired branding into generation flow:
  - caption prompt now includes preferred brand tone
  - image renderer now uses primary + secondary colors and displays tone/logo context in the generated template

## Testing
- `npm run lint`
- `npm run test`
- `npm run typecheck`
- `npm run build`