### PR TITLE
feat: add per-business branding settings and tone support

### DIFF
--- a/app/api/businesses/[id]/route.ts
+++ b/app/api/businesses/[id]/route.ts
@@ -1,7 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
+import { parseBrandColors, parseLogoUrl, type BrandTone } from "../../../../lib/branding";
 import { query } from "../../../../lib/db";
 
-type BrandTone = "friendly" | "premium" | "playful";
+type BusinessRow = {
+  id: number;
+  name: string;
+  timezone: string;
+  brand_colors: Record<string, string> | null;
+  logo_url: string | null;
+  brand_tone: BrandTone;
+};
+
+function normalizeBrandTone(input: unknown): BrandTone {
+  const tone = String(input ?? "friendly").trim().toLowerCase();
+  if (tone === "premium" || tone === "playful") return tone;
+  return "friendly";
+}
 
 function normalizeHex(input: unknown): string | null {
   const value = String(input ?? "").trim();
@@ -10,60 +24,107 @@ function normalizeHex(input: unknown): string | null {
   return value.startsWith("#") ? value.toLowerCase() : `#${value.toLowerCase()}`;
 }
 
-function normalizeBrandTone(input: unknown): BrandTone {
-  const tone = String(input ?? "friendly").trim().toLowerCase();
-  if (tone === "premium" || tone === "playful") return tone;
-  return "friendly";
-}
-
-export async function PATCH(
-  req: NextRequest,
-  context: { params: Promise<{ id: string }> }
-) {
-  const { id } = await context.params;
-  const businessId = Number(id);
+export async function PATCH(req: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const params = await context.params;
+  const businessId = Number(params.id);
 
   if (!Number.isInteger(businessId) || businessId <= 0) {
     return NextResponse.json({ error: "valid business id is required" }, { status: 400 });
   }
 
   const body = await req.json();
-  const logoUrl = String(body?.logoUrl ?? "").trim() || null;
-  const primaryColor = normalizeHex(body?.primaryColor);
-  const secondaryColor = normalizeHex(body?.secondaryColor);
-  const brandTone = normalizeBrandTone(body?.brandTone);
 
-  if (!primaryColor || !secondaryColor) {
-    return NextResponse.json(
-      { error: "primaryColor and secondaryColor must be valid 6-digit hex colors" },
-      { status: 400 }
+  const hasLegacyColorFields = body?.primaryColor !== undefined || body?.secondaryColor !== undefined;
+  const hasExtendedFields =
+    body?.name !== undefined || body?.timezone !== undefined || body?.brandColors !== undefined;
+
+  if (hasLegacyColorFields && !hasExtendedFields) {
+    const primaryColor = normalizeHex(body?.primaryColor);
+    const secondaryColor = normalizeHex(body?.secondaryColor);
+    if (!primaryColor || !secondaryColor) {
+      return NextResponse.json(
+        { error: "primaryColor and secondaryColor must be valid 6-digit hex colors" },
+        { status: 400 }
+      );
+    }
+
+    const logoUrl = parseLogoUrl(body?.logoUrl);
+    const brandTone = normalizeBrandTone(body?.brandTone);
+
+    const result = await query<{
+      id: number;
+      name: string;
+      logo_url: string | null;
+      brand_tone: BrandTone;
+      brand_colors: { primary?: string; secondary?: string };
+    }>(
+      `UPDATE businesses
+       SET logo_url = $2,
+           brand_colors = $3::jsonb,
+           brand_tone = $4
+       WHERE id = $1
+       RETURNING id, name, logo_url, brand_tone, brand_colors`,
+      [
+        businessId,
+        logoUrl,
+        JSON.stringify({ primary: primaryColor, secondary: secondaryColor }),
+        brandTone
+      ]
     );
+
+    if (!result.rowCount) {
+      return NextResponse.json({ error: "business not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ business: result.rows[0] });
   }
 
-  const result = await query<{
-    id: number;
-    name: string;
-    logo_url: string | null;
-    brand_tone: BrandTone;
-    brand_colors: { primary?: string; secondary?: string };
-  }>(
-    `UPDATE businesses
-     SET logo_url = $2,
-         brand_colors = $3::jsonb,
-         brand_tone = $4
+  const existing = await query<BusinessRow>(
+    `SELECT id, name, timezone, brand_colors, logo_url, brand_tone
+     FROM businesses
      WHERE id = $1
-     RETURNING id, name, logo_url, brand_tone, brand_colors`,
-    [
-      businessId,
-      logoUrl,
-      JSON.stringify({ primary: primaryColor, secondary: secondaryColor }),
-      brandTone
-    ]
+     LIMIT 1`,
+    [businessId]
   );
 
-  if (!result.rowCount) {
+  if (!existing.rowCount) {
     return NextResponse.json({ error: "business not found" }, { status: 404 });
   }
 
-  return NextResponse.json({ business: result.rows[0] });
+  const current = existing.rows[0];
+
+  const name = body?.name === undefined ? current.name : String(body.name ?? "").trim();
+  if (!name) {
+    return NextResponse.json({ error: "name cannot be empty" }, { status: 400 });
+  }
+
+  const timezone =
+    body?.timezone === undefined
+      ? current.timezone
+      : String(body.timezone ?? "").trim() || current.timezone;
+
+  let brandColors: Record<string, string> = current.brand_colors ?? {};
+  if (body?.brandColors !== undefined) {
+    brandColors = parseBrandColors(body.brandColors);
+  }
+
+  const logoRaw = body?.logoUrl === undefined ? current.logo_url : body.logoUrl;
+  const logoUrl = parseLogoUrl(logoRaw);
+
+  const toneCandidate =
+    body?.brandTone === undefined ? current.brand_tone : normalizeBrandTone(body.brandTone);
+
+  const updated = await query<BusinessRow>(
+    `UPDATE businesses
+     SET name = $2,
+         timezone = $3,
+         brand_colors = $4::jsonb,
+         logo_url = $5,
+         brand_tone = $6
+     WHERE id = $1
+     RETURNING id, name, timezone, brand_colors, logo_url, brand_tone`,
+    [businessId, name, timezone, JSON.stringify(brandColors), logoUrl, toneCandidate]
+  );
+
+  return NextResponse.json({ business: updated.rows[0] });
 }

--- a/app/api/businesses/route.ts
+++ b/app/api/businesses/route.ts
@@ -1,14 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { parseBrandColors, parseLogoUrl, type BrandTone } from "../../../lib/branding";
 import { query } from "../../../lib/db";
-
-type BrandTone = "friendly" | "premium" | "playful";
-
-function normalizeHex(input: unknown): string | null {
-  const value = String(input ?? "").trim();
-  if (!value) return null;
-  if (!/^#?[0-9a-fA-F]{6}$/.test(value)) return null;
-  return value.startsWith("#") ? value.toLowerCase() : `#${value.toLowerCase()}`;
-}
 
 function normalizeBrandTone(input: unknown): BrandTone {
   const tone = String(input ?? "friendly").trim().toLowerCase();
@@ -20,16 +12,20 @@ export async function GET() {
   const result = await query<{
     id: number;
     name: string;
+    timezone: string;
+    brand_colors: Record<string, string> | null;
     logo_url: string | null;
     brand_tone: BrandTone;
-    brand_colors: { primary?: string; secondary?: string } | null;
   }>(
-    "SELECT id, name, logo_url, brand_tone, brand_colors FROM businesses ORDER BY id ASC"
+    `SELECT id, name, timezone, brand_colors, logo_url, brand_tone
+     FROM businesses
+     ORDER BY id ASC`
   );
 
   const businesses = result.rows.map((row) => ({
     id: row.id,
     name: row.name,
+    timezone: row.timezone,
     logo_url: row.logo_url,
     brand_tone: row.brand_tone,
     brand_colors: {
@@ -45,9 +41,21 @@ export async function POST(req: NextRequest) {
   const body = await req.json();
   const name = String(body?.name ?? "").trim();
   const timezone = String(body?.timezone ?? "America/Toronto").trim();
-  const logoUrl = String(body?.logoUrl ?? "").trim() || null;
-  const primaryColor = normalizeHex(body?.primaryColor) ?? "#1f2937";
-  const secondaryColor = normalizeHex(body?.secondaryColor) ?? "#374151";
+
+  const parsedBrandColors =
+    body?.brandColors !== undefined
+      ? parseBrandColors(body.brandColors)
+      : parseBrandColors({
+          primary: body?.primaryColor,
+          secondary: body?.secondaryColor
+        });
+
+  const brandColors = {
+    primary: parsedBrandColors.primary ?? "#1f2937",
+    secondary: parsedBrandColors.secondary ?? "#374151"
+  };
+
+  const logoUrl = parseLogoUrl(body?.logoUrl);
   const brandTone = normalizeBrandTone(body?.brandTone);
 
   if (!name) {
@@ -57,20 +65,15 @@ export async function POST(req: NextRequest) {
   const result = await query<{
     id: number;
     name: string;
+    timezone: string;
+    brand_colors: Record<string, string> | null;
     logo_url: string | null;
     brand_tone: BrandTone;
-    brand_colors: { primary?: string; secondary?: string };
   }>(
     `INSERT INTO businesses (name, timezone, brand_colors, logo_url, brand_tone)
      VALUES ($1, $2, $3::jsonb, $4, $5)
-     RETURNING id, name, logo_url, brand_tone, brand_colors`,
-    [
-      name,
-      timezone,
-      JSON.stringify({ primary: primaryColor, secondary: secondaryColor }),
-      logoUrl,
-      brandTone
-    ]
+     RETURNING id, name, timezone, brand_colors, logo_url, brand_tone`,
+    [name, timezone, JSON.stringify(brandColors), logoUrl, brandTone]
   );
 
   return NextResponse.json({ business: result.rows[0] }, { status: 201 });

--- a/app/api/captions/generate/route.ts
+++ b/app/api/captions/generate/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { query } from "../../../../lib/db";
+import type { BrandTone } from "../../../../lib/branding";
 import { generateCaptionVariants } from "../../../../lib/services/captions";
 
 export async function POST(req: NextRequest) {
@@ -15,7 +16,7 @@ export async function POST(req: NextRequest) {
       id: number;
       quote_text: string;
       business_name: string;
-      brand_tone: "friendly" | "premium" | "playful";
+      brand_tone: BrandTone;
     }>(
       `SELECT d.id, d.quote_text, b.name AS business_name, b.brand_tone
        FROM draft_posts d

--- a/app/api/images/render/route.ts
+++ b/app/api/images/render/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { query } from "../../../../lib/db";
+import type { BrandTone } from "../../../../lib/branding";
 import { renderDraftImage } from "../../../../lib/services/imageRenderer";
 
 export async function POST(req: NextRequest) {
@@ -17,7 +18,7 @@ export async function POST(req: NextRequest) {
       business_name: string;
       brand_colors: Record<string, string> | null;
       logo_url: string | null;
-      brand_tone: "friendly" | "premium" | "playful";
+      brand_tone: BrandTone;
     }>(
       `SELECT d.id, d.quote_text, b.name AS business_name, b.brand_colors, b.logo_url, b.brand_tone
        FROM draft_posts d

--- a/app/import/page.tsx
+++ b/app/import/page.tsx
@@ -7,12 +7,10 @@ type BrandTone = "friendly" | "premium" | "playful";
 type Business = {
   id: number;
   name: string;
-  logo_url?: string | null;
-  brand_tone?: BrandTone;
-  brand_colors?: {
-    primary?: string;
-    secondary?: string;
-  };
+  timezone: string;
+  brand_colors: { primary?: string; secondary?: string } | null;
+  logo_url: string | null;
+  brand_tone: BrandTone;
 };
 
 type Review = {
@@ -26,24 +24,24 @@ type Review = {
 const DEFAULT_PRIMARY = "#1f2937";
 const DEFAULT_SECONDARY = "#374151";
 
-function normalizeHex(value: string): string {
-  const trimmed = value.trim();
-  if (!trimmed) return "";
-  if (!/^#?[0-9a-fA-F]{6}$/.test(trimmed)) return "";
-  return trimmed.startsWith("#") ? trimmed.toLowerCase() : `#${trimmed.toLowerCase()}`;
-}
-
 export default function ImportPage() {
   const [businesses, setBusinesses] = useState<Business[]>([]);
   const [selectedBusinessId, setSelectedBusinessId] = useState<string>("");
   const [newBusinessName, setNewBusinessName] = useState("");
+  const [newBusinessLogoUrl, setNewBusinessLogoUrl] = useState("");
+  const [newBusinessPrimaryColor, setNewBusinessPrimaryColor] = useState(DEFAULT_PRIMARY);
+  const [newBusinessSecondaryColor, setNewBusinessSecondaryColor] = useState(DEFAULT_SECONDARY);
+  const [newBusinessTone, setNewBusinessTone] = useState<BrandTone>("friendly");
+
+  const [settingsName, setSettingsName] = useState("");
+  const [settingsTimezone, setSettingsTimezone] = useState("America/Toronto");
+  const [settingsLogoUrl, setSettingsLogoUrl] = useState("");
+  const [settingsPrimaryColor, setSettingsPrimaryColor] = useState(DEFAULT_PRIMARY);
+  const [settingsSecondaryColor, setSettingsSecondaryColor] = useState(DEFAULT_SECONDARY);
+  const [settingsTone, setSettingsTone] = useState<BrandTone>("friendly");
+
   const [result, setResult] = useState<string>("");
   const [reviews, setReviews] = useState<Review[]>([]);
-
-  const [logoUrl, setLogoUrl] = useState("");
-  const [primaryColor, setPrimaryColor] = useState(DEFAULT_PRIMARY);
-  const [secondaryColor, setSecondaryColor] = useState(DEFAULT_SECONDARY);
-  const [brandTone, setBrandTone] = useState<BrandTone>("friendly");
 
   const selectedBusiness = useMemo(
     () => businesses.find((b) => String(b.id) === selectedBusinessId) ?? null,
@@ -76,17 +74,21 @@ export default function ImportPage() {
 
   useEffect(() => {
     if (!selectedBusiness) {
-      setLogoUrl("");
-      setPrimaryColor(DEFAULT_PRIMARY);
-      setSecondaryColor(DEFAULT_SECONDARY);
-      setBrandTone("friendly");
+      setSettingsName("");
+      setSettingsTimezone("America/Toronto");
+      setSettingsLogoUrl("");
+      setSettingsPrimaryColor(DEFAULT_PRIMARY);
+      setSettingsSecondaryColor(DEFAULT_SECONDARY);
+      setSettingsTone("friendly");
       return;
     }
 
-    setLogoUrl(selectedBusiness.logo_url ?? "");
-    setPrimaryColor(selectedBusiness.brand_colors?.primary ?? DEFAULT_PRIMARY);
-    setSecondaryColor(selectedBusiness.brand_colors?.secondary ?? DEFAULT_SECONDARY);
-    setBrandTone(selectedBusiness.brand_tone ?? "friendly");
+    setSettingsName(selectedBusiness.name);
+    setSettingsTimezone(selectedBusiness.timezone || "America/Toronto");
+    setSettingsLogoUrl(selectedBusiness.logo_url ?? "");
+    setSettingsPrimaryColor(selectedBusiness.brand_colors?.primary ?? DEFAULT_PRIMARY);
+    setSettingsSecondaryColor(selectedBusiness.brand_colors?.secondary ?? DEFAULT_SECONDARY);
+    setSettingsTone(selectedBusiness.brand_tone ?? "friendly");
   }, [selectedBusiness]);
 
   async function createBusiness(e: FormEvent<HTMLFormElement>) {
@@ -100,10 +102,12 @@ export default function ImportPage() {
       body: JSON.stringify({
         name,
         timezone: "America/Toronto",
-        logoUrl,
-        primaryColor: normalizeHex(primaryColor) || DEFAULT_PRIMARY,
-        secondaryColor: normalizeHex(secondaryColor) || DEFAULT_SECONDARY,
-        brandTone
+        logoUrl: newBusinessLogoUrl.trim() || null,
+        brandColors: {
+          primary: newBusinessPrimaryColor,
+          secondary: newBusinessSecondaryColor
+        },
+        brandTone: newBusinessTone
       })
     });
     const data = await res.json();
@@ -113,41 +117,43 @@ export default function ImportPage() {
     }
 
     setNewBusinessName("");
+    setNewBusinessLogoUrl("");
+    setNewBusinessPrimaryColor(DEFAULT_PRIMARY);
+    setNewBusinessSecondaryColor(DEFAULT_SECONDARY);
+    setNewBusinessTone("friendly");
+
     await loadBusinesses();
     setSelectedBusinessId(String(data.business.id));
     setResult(`Created business: ${data.business.name}`);
   }
 
-  async function saveBranding(e: FormEvent<HTMLFormElement>) {
+  async function saveBrandingSettings(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     if (!selectedBusinessId) return;
-
-    const normalizedPrimary = normalizeHex(primaryColor);
-    const normalizedSecondary = normalizeHex(secondaryColor);
-    if (!normalizedPrimary || !normalizedSecondary) {
-      setResult("Branding save failed: colors must be valid hex (e.g. #1f2937)");
-      return;
-    }
 
     const res = await fetch(`/api/businesses/${selectedBusinessId}`, {
       method: "PATCH",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
-        logoUrl: logoUrl.trim(),
-        primaryColor: normalizedPrimary,
-        secondaryColor: normalizedSecondary,
-        brandTone
+        name: settingsName,
+        timezone: settingsTimezone,
+        logoUrl: settingsLogoUrl.trim() || null,
+        brandColors: {
+          primary: settingsPrimaryColor,
+          secondary: settingsSecondaryColor
+        },
+        brandTone: settingsTone
       })
     });
 
     const data = await res.json();
     if (!res.ok) {
-      setResult(`Branding save failed: ${data.error ?? "unknown error"}`);
+      setResult(`Update branding failed: ${data.error ?? "unknown error"}`);
       return;
     }
 
-    setResult(`Saved branding for ${data.business.name}`);
     await loadBusinesses();
+    setResult(`Saved branding settings for: ${data.business.name}`);
   }
 
   async function importCsv(e: FormEvent<HTMLFormElement>) {
@@ -177,13 +183,45 @@ export default function ImportPage() {
 
       <section style={{ marginBottom: 20 }}>
         <h2>Create business</h2>
-        <form onSubmit={createBusiness}>
+        <form onSubmit={createBusiness} style={{ display: "grid", gap: 8, maxWidth: 520 }}>
           <input
             value={newBusinessName}
             onChange={(e) => setNewBusinessName(e.target.value)}
             placeholder="Business name"
           />
-          <button type="submit" style={{ marginLeft: 8 }}>
+          <input
+            value={newBusinessLogoUrl}
+            onChange={(e) => setNewBusinessLogoUrl(e.target.value)}
+            placeholder="Logo URL (optional)"
+          />
+          <label>
+            Primary color{" "}
+            <input
+              type="color"
+              value={newBusinessPrimaryColor}
+              onChange={(e) => setNewBusinessPrimaryColor(e.target.value)}
+            />
+          </label>
+          <label>
+            Secondary color{" "}
+            <input
+              type="color"
+              value={newBusinessSecondaryColor}
+              onChange={(e) => setNewBusinessSecondaryColor(e.target.value)}
+            />
+          </label>
+          <label>
+            Brand tone{" "}
+            <select
+              value={newBusinessTone}
+              onChange={(e) => setNewBusinessTone(e.target.value as BrandTone)}
+            >
+              <option value="friendly">friendly</option>
+              <option value="premium">premium</option>
+              <option value="playful">playful</option>
+            </select>
+          </label>
+          <button type="submit" style={{ width: "fit-content" }}>
             Create
           </button>
         </form>
@@ -191,10 +229,7 @@ export default function ImportPage() {
 
       <section style={{ marginBottom: 20 }}>
         <h2>Select business</h2>
-        <select
-          value={selectedBusinessId}
-          onChange={(e) => setSelectedBusinessId(e.target.value)}
-        >
+        <select value={selectedBusinessId} onChange={(e) => setSelectedBusinessId(e.target.value)}>
           <option value="">Select…</option>
           {businesses.map((b) => (
             <option key={b.id} value={b.id}>
@@ -204,60 +239,55 @@ export default function ImportPage() {
         </select>
       </section>
 
-      <section style={{ marginBottom: 20 }}>
-        <h2>Branding settings</h2>
-        <p>Logo + colors + tone are used for captions and rendered image templates.</p>
-        <form onSubmit={saveBranding}>
-          <div style={{ display: "grid", gap: 8, maxWidth: 520 }}>
+      {selectedBusinessId ? (
+        <section style={{ marginBottom: 20 }}>
+          <h2>Branding settings</h2>
+          <form onSubmit={saveBrandingSettings} style={{ display: "grid", gap: 8, maxWidth: 520 }}>
+            <input
+              value={settingsName}
+              onChange={(e) => setSettingsName(e.target.value)}
+              placeholder="Business name"
+            />
+            <input
+              value={settingsTimezone}
+              onChange={(e) => setSettingsTimezone(e.target.value)}
+              placeholder="Timezone"
+            />
+            <input
+              value={settingsLogoUrl}
+              onChange={(e) => setSettingsLogoUrl(e.target.value)}
+              placeholder="Logo URL"
+            />
             <label>
-              Logo URL
+              Primary color{" "}
               <input
-                value={logoUrl}
-                onChange={(e) => setLogoUrl(e.target.value)}
-                placeholder="https://example.com/logo.png"
-                style={{ display: "block", width: "100%" }}
+                type="color"
+                value={settingsPrimaryColor}
+                onChange={(e) => setSettingsPrimaryColor(e.target.value)}
               />
             </label>
-
             <label>
-              Primary color
+              Secondary color{" "}
               <input
-                value={primaryColor}
-                onChange={(e) => setPrimaryColor(e.target.value)}
-                placeholder="#1f2937"
-                style={{ display: "block", width: "100%" }}
+                type="color"
+                value={settingsSecondaryColor}
+                onChange={(e) => setSettingsSecondaryColor(e.target.value)}
               />
             </label>
-
             <label>
-              Secondary color
-              <input
-                value={secondaryColor}
-                onChange={(e) => setSecondaryColor(e.target.value)}
-                placeholder="#374151"
-                style={{ display: "block", width: "100%" }}
-              />
-            </label>
-
-            <label>
-              Brand tone
-              <select
-                value={brandTone}
-                onChange={(e) => setBrandTone(e.target.value as BrandTone)}
-                style={{ display: "block", width: "100%" }}
-              >
+              Brand tone{" "}
+              <select value={settingsTone} onChange={(e) => setSettingsTone(e.target.value as BrandTone)}>
                 <option value="friendly">friendly</option>
                 <option value="premium">premium</option>
                 <option value="playful">playful</option>
               </select>
             </label>
-          </div>
-
-          <button type="submit" disabled={!selectedBusinessId} style={{ marginTop: 10 }}>
-            Save branding
-          </button>
-        </form>
-      </section>
+            <button type="submit" style={{ width: "fit-content" }}>
+              Save branding settings
+            </button>
+          </form>
+        </section>
+      ) : null}
 
       <section style={{ marginBottom: 20 }}>
         <h2>Upload CSV</h2>

--- a/db/migrations/004_add_brand_tone_to_businesses.sql
+++ b/db/migrations/004_add_brand_tone_to_businesses.sql
@@ -1,0 +1,3 @@
+ALTER TABLE businesses
+  ADD COLUMN IF NOT EXISTS brand_tone TEXT NOT NULL DEFAULT 'friendly'
+  CHECK (brand_tone IN ('friendly', 'premium', 'playful'));

--- a/lib/branding.ts
+++ b/lib/branding.ts
@@ -1,0 +1,32 @@
+export const BRAND_TONES = ["friendly", "premium", "playful"] as const;
+export type BrandTone = (typeof BRAND_TONES)[number];
+
+export function isBrandTone(value: unknown): value is BrandTone {
+  return typeof value === "string" && BRAND_TONES.includes(value as BrandTone);
+}
+
+function normalizeHex(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const withHash = trimmed.startsWith("#") ? trimmed : `#${trimmed}`;
+  return /^#[0-9a-fA-F]{6}$/.test(withHash) ? withHash.toLowerCase() : null;
+}
+
+export function parseBrandColors(input: unknown): Record<string, string> {
+  const source = input && typeof input === "object" ? (input as Record<string, unknown>) : {};
+
+  const primary = normalizeHex(source.primary);
+  const secondary = normalizeHex(source.secondary);
+
+  const brandColors: Record<string, string> = {};
+  if (primary) brandColors.primary = primary;
+  if (secondary) brandColors.secondary = secondary;
+  return brandColors;
+}
+
+export function parseLogoUrl(input: unknown): string | null {
+  if (typeof input !== "string") return null;
+  const trimmed = input.trim();
+  return trimmed || null;
+}

--- a/lib/services/captions.ts
+++ b/lib/services/captions.ts
@@ -1,3 +1,5 @@
+import { BRAND_TONES, type BrandTone } from "../branding";
+
 type CaptionStyles = {
   friendly: string;
   premium: string;
@@ -28,19 +30,21 @@ function sanitizeCaption(text: string): string {
 export async function generateCaptionVariants(params: {
   businessName: string;
   quoteText: string;
-  brandTone?: "friendly" | "premium" | "playful";
+  brandTone?: BrandTone;
 }): Promise<CaptionStyles> {
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) {
     throw new Error("OPENAI_API_KEY is not set");
   }
 
-  const preferredTone = params.brandTone ?? "friendly";
+  const requestedTone = params.brandTone && BRAND_TONES.includes(params.brandTone)
+    ? params.brandTone
+    : "friendly";
 
   const prompt = `You are writing social captions for a local business.
 Business: ${params.businessName}
 Quote: "${params.quoteText}"
-Preferred brand tone: ${preferredTone}
+Preferred brand tone: ${requestedTone}
 
 Return ONLY JSON with keys friendly, premium, playful.
 Rules:
@@ -48,7 +52,7 @@ Rules:
 - each caption <= 200 chars
 - max 5 hashtags per caption
 - no markdown, no extra keys
-- make the ${preferredTone} caption the strongest/highest-quality option`;
+- lean the ${requestedTone} caption closest to the preferred tone`;
 
   const res = await fetch("https://api.openai.com/v1/responses", {
     method: "POST",

--- a/lib/services/draftPipeline.ts
+++ b/lib/services/draftPipeline.ts
@@ -2,12 +2,14 @@ import { renderDraftImage } from "./imageRenderer";
 import { selectQuoteCandidates } from "./quoteSelector";
 import { generateCaptionVariants } from "./captions";
 import { query } from "../db";
+import type { BrandTone } from "../branding";
 
 type BusinessRow = {
   id: number;
   name: string;
   brand_colors: Record<string, string> | null;
   logo_url: string | null;
+  brand_tone: BrandTone;
 };
 
 type CandidateRow = {
@@ -33,21 +35,22 @@ export type PipelineResult = {
 type DraftPipelineDeps = {
   listBusinesses: () => Promise<BusinessRow[]>;
   selectQuoteCandidates: (businessId: number, limit: number) => Promise<CandidateRow[]>;
-  generateCaptionVariants: (params: { businessName: string; quoteText: string }) => Promise<CaptionSet>;
+  generateCaptionVariants: (params: { businessName: string; quoteText: string; brandTone?: BrandTone }) => Promise<CaptionSet>;
   updateDraftCaption: (draftPostId: number, captionText: string) => Promise<void>;
   renderDraftImage: (params: {
     draftPostId: number;
     businessName: string;
     quoteText: string;
     brandHex?: string | null;
+    secondaryBrandHex?: string | null;
     logoUrl?: string | null;
   }) => Promise<{ publicPath: string }>;
   updateDraftImagePath: (draftPostId: number, imagePath: string) => Promise<void>;
   markDraftFailed: (draftPostId: number, reason: string) => Promise<void>;
 };
 
-function pickCaption(captions: CaptionSet) {
-  return captions.friendly || captions.premium || captions.playful;
+function pickCaption(captions: CaptionSet, brandTone: BrandTone) {
+  return captions[brandTone] || captions.friendly || captions.premium || captions.playful;
 }
 
 export function createDraftGenerationRunner(deps: DraftPipelineDeps) {
@@ -67,17 +70,20 @@ export function createDraftGenerationRunner(deps: DraftPipelineDeps) {
         try {
           const captions = await deps.generateCaptionVariants({
             businessName: business.name,
-            quoteText: candidate.quoteText
+            quoteText: candidate.quoteText,
+            brandTone: business.brand_tone
           });
 
-          await deps.updateDraftCaption(candidate.draftPostId, pickCaption(captions));
+          await deps.updateDraftCaption(candidate.draftPostId, pickCaption(captions, business.brand_tone));
 
           const brandHex = business.brand_colors?.primary ?? null;
+          const secondaryBrandHex = business.brand_colors?.secondary ?? null;
           const rendered = await deps.renderDraftImage({
             draftPostId: candidate.draftPostId,
             businessName: business.name,
             quoteText: candidate.quoteText,
             brandHex,
+            secondaryBrandHex,
             logoUrl: business.logo_url
           });
 
@@ -103,7 +109,7 @@ export function createDraftGenerationRunner(deps: DraftPipelineDeps) {
 const runDraftGenerationWithDb = createDraftGenerationRunner({
   listBusinesses: async () => {
     const businesses = await query<BusinessRow>(
-      `SELECT id, name, brand_colors, logo_url
+      `SELECT id, name, brand_colors, logo_url, brand_tone
        FROM businesses
        ORDER BY id ASC`
     );

--- a/lib/services/imageRenderer.ts
+++ b/lib/services/imageRenderer.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import sharp from "sharp";
+import type { BrandTone } from "../branding";
 
 function esc(text: string): string {
   return text
@@ -11,6 +12,14 @@ function esc(text: string): string {
     .replaceAll("'", "&#39;");
 }
 
+function normalizeHex(color?: string | null): string | null {
+  if (!color) return null;
+  const trimmed = color.trim();
+  if (!trimmed) return null;
+  const withHash = trimmed.startsWith("#") ? trimmed : `#${trimmed}`;
+  return /^#[0-9a-fA-F]{6}$/.test(withHash) ? withHash.toLowerCase() : null;
+}
+
 export async function renderDraftImage(params: {
   draftPostId: number;
   businessName: string;
@@ -18,19 +27,13 @@ export async function renderDraftImage(params: {
   brandHex?: string | null;
   secondaryBrandHex?: string | null;
   logoUrl?: string | null;
-  brandTone?: "friendly" | "premium" | "playful";
+  brandTone?: BrandTone;
 }) {
   const width = 1080;
   const height = 1080;
 
-  const normalizeHex = (input: string | null | undefined, fallback: string) => {
-    if (!input) return fallback;
-    if (!/^#?[0-9a-fA-F]{6}$/.test(input)) return fallback;
-    return input.startsWith("#") ? input : `#${input}`;
-  };
-
-  const primary = normalizeHex(params.brandHex, "#1f2937");
-  const secondary = normalizeHex(params.secondaryBrandHex, "#374151");
+  const primary = normalizeHex(params.brandHex) ?? "#1f2937";
+  const secondary = normalizeHex(params.secondaryBrandHex) ?? "#374151";
 
   const tone = params.brandTone ?? "friendly";
   const toneFont = tone === "premium" ? "Georgia,serif" : "Arial,sans-serif";

--- a/scripts/test-draft-pipeline.ts
+++ b/scripts/test-draft-pipeline.ts
@@ -4,23 +4,33 @@ import { createDraftGenerationRunner } from "../lib/services/draftPipeline";
 async function successPathTest() {
   const updatedCaptions: Array<{ id: number; caption: string }> = [];
   const updatedImages: Array<{ id: number; imagePath: string }> = [];
+  const renderInputs: Array<{ brandHex?: string | null; secondaryBrandHex?: string | null }> = [];
 
   const run = createDraftGenerationRunner({
     listBusinesses: async () => [
-      { id: 7, name: "Cafe Nova", brand_colors: { primary: "#112233" }, logo_url: null }
+      {
+        id: 7,
+        name: "Cafe Nova",
+        brand_colors: { primary: "#112233", secondary: "#334455" },
+        logo_url: null,
+        brand_tone: "premium"
+      }
     ],
     selectQuoteCandidates: async () => [
       { draftPostId: 101, reviewId: 501, quoteText: "Amazing coffee and staff", score: 100 }
     ],
     generateCaptionVariants: async () => ({
       friendly: "Cafe Nova made our day ☕",
-      premium: "",
-      playful: ""
+      premium: "An elevated evening, made memorable at Cafe Nova.",
+      playful: "Coffee joy unlocked at Cafe Nova!"
     }),
     updateDraftCaption: async (id, caption) => {
       updatedCaptions.push({ id, caption });
     },
-    renderDraftImage: async () => ({ publicPath: "/generated/draft-101.png" }),
+    renderDraftImage: async (params) => {
+      renderInputs.push({ brandHex: params.brandHex, secondaryBrandHex: params.secondaryBrandHex });
+      return { publicPath: "/generated/draft-101.png" };
+    },
     updateDraftImagePath: async (id, imagePath) => {
       updatedImages.push({ id, imagePath });
     },
@@ -37,8 +47,11 @@ async function successPathTest() {
     draftsCompleted: 1,
     draftsFailed: 0
   });
-  assert.deepEqual(updatedCaptions, [{ id: 101, caption: "Cafe Nova made our day ☕" }]);
+  assert.deepEqual(updatedCaptions, [
+    { id: 101, caption: "An elevated evening, made memorable at Cafe Nova." }
+  ]);
   assert.deepEqual(updatedImages, [{ id: 101, imagePath: "/generated/draft-101.png" }]);
+  assert.deepEqual(renderInputs, [{ brandHex: "#112233", secondaryBrandHex: "#334455" }]);
 }
 
 async function failurePathTest() {
@@ -46,7 +59,7 @@ async function failurePathTest() {
 
   const run = createDraftGenerationRunner({
     listBusinesses: async () => [
-      { id: 8, name: "North Pizza", brand_colors: null, logo_url: null }
+      { id: 8, name: "North Pizza", brand_colors: null, logo_url: null, brand_tone: "friendly" }
     ],
     selectQuoteCandidates: async () => [
       { draftPostId: 202, reviewId: 601, quoteText: "Great service", score: 88 }


### PR DESCRIPTION
Closes #25

## Summary
- add reusable branding helpers plus a migration + API updates for `brand_tone`
- add `PATCH /api/businesses/:id` and extend business create/list payloads for logo/colors/tone
- wire business `brand_tone` into caption generation and draft pipeline caption selection
- wire primary + secondary colors into image rendering (gradient template)
- add branding settings UI on `/import` so each business can configure logo/colors/tone
- update draft pipeline tests to validate tone-based caption selection and color propagation

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`